### PR TITLE
Numerous trivial edits to NaturalNumbers

### DIFF
--- a/NaturalNumbers/AdditionWorld.lean
+++ b/NaturalNumbers/AdditionWorld.lean
@@ -6,7 +6,7 @@ import AdditionWorld.Level5
 import AdditionWorld.Level6
 
 /-!
-# Addition World.
+# Addition World
 
 Welcome to Addition World. If you've done all four levels in [Tutorial
 World](../TutorialWorld/Level1.lean.md) and know about `rewrite`, `rw` and `rfl`, then you're in the
@@ -16,7 +16,7 @@ you're now equipped with which we'll need in this world.
 ## Data:
 
   * a type called `MyNat`
-  * a term `(0 : MyNat)`, interpreted as the number zero.
+  * a term `0 : MyNat`, interpreted as the number zero.
   * a function `succ : MyNat → MyNat`, with `succ n` interpreted as "the number after `n`".
   * Usual numerical notation 0,1,2 etc (although 2 onwards will be of no use to us until much later ;-) ).
   * Addition (with notation `a + b`).
@@ -25,12 +25,12 @@ you're now equipped with which we'll need in this world.
 
   * `add_zero (a : MyNat) : a + 0 = a`. Use with `rw [add_zero]`.
   * `add_succ (a b : MyNat) : a + succ b = succ (a + b)`. Use with `rw [add_succ]`.
-  * The principle of mathematical induction. Use with `induction` (see below)
+  * The principle of mathematical induction. Use with `induction` (see below).
 
 
 ## Tactics:
 
-  * `rfl` :  proves goals of the form `X = X`
+  * `rfl` :  proves goals of the form `X = X`.
   * `rw [h]` : if h is a proof of `A = B`, changes all A's in the goal to B's.
   * `induction n with ...` : we're going to learn this right now.
 

--- a/NaturalNumbers/AdditionWorld.lean
+++ b/NaturalNumbers/AdditionWorld.lean
@@ -15,8 +15,8 @@ you're now equipped with which we'll need in this world.
 
 ## Data:
 
-  * a type called `MyNat`
-  * a term `0 : MyNat`, interpreted as the number zero.
+  * a type called `MyNat`.
+  * a term `0 : MyNat`, interpreted as the number `zero`.
   * a function `succ : MyNat → MyNat`, with `succ n` interpreted as "the number after `n`".
   * Usual numerical notation 0,1,2 etc (although 2 onwards will be of no use to us until much later ;-) ).
   * Addition (with notation `a + b`).

--- a/NaturalNumbers/AdditionWorld/Level1.lean
+++ b/NaturalNumbers/AdditionWorld/Level1.lean
@@ -3,9 +3,9 @@ namespace MyNat
 open MyNat
 
 /-!
-# Addition World.
+# Addition World
 
-## Level 1: the `induction` tactic.
+## Level 1: the `induction` tactic
 
 OK so let's see induction in action. We're going to prove
 
@@ -24,7 +24,7 @@ if you've used Goto Definition (F12) on this theorem you can even see it). To pr
 need to use induction on `n`. While we're here, note that `zero_add` is about zero add something,
 and `add_zero` is about something add zero. The names of the proofs tell you what the theorems are.
 
-**Lemma**
+## Lemma
 
 For all natural numbers `n`, we have `0 + n = n.`
 -/
@@ -41,8 +41,8 @@ Notice that the [induction tactic](../Tactics/induction.lean.md) has created *tw
 which you can match using vertical bar pattern patching.
 
 The induction tactic has generated for us a base case with `n = zero` (the goal at the top)
-and an inductive step (the goal underneath). The golden rule: **Tactics operate on the first goal**
-- the goal at the top. So let's just worry about that top goal now, the base case.
+and an inductive step (the goal underneath). The golden rule: **Tactics operate on the first goal**.
+- The goal at the top. So let's just worry about that top goal now, the base case.
 If you place the cursor right after the `=>` symbol you will see the goal listed in
 the InfoView as `⊢ 0 + zero = zero`.
 

--- a/NaturalNumbers/AdditionWorld/Level1.lean
+++ b/NaturalNumbers/AdditionWorld/Level1.lean
@@ -26,7 +26,7 @@ and `add_zero` is about something add zero. The names of the proofs tell you wha
 
 ## Lemma
 
-For all natural numbers `n`, we have `0 + n = n.`
+For all natural numbers `n`, we have `0 + n = n`.
 -/
 lemma zero_add (n : MyNat) : 0 + n = n := by
   induction n with

--- a/NaturalNumbers/AdditionWorld/Level2.lean
+++ b/NaturalNumbers/AdditionWorld/Level2.lean
@@ -2,7 +2,7 @@ import MyNat.Addition -- imports addition.
 namespace MyNat
 open MyNat
 /-!
-# Addition world
+# Addition World
 
 ## Level 2: `add_assoc` -- associativity of addition.
 

--- a/NaturalNumbers/AdditionWorld/Level2.lean
+++ b/NaturalNumbers/AdditionWorld/Level2.lean
@@ -4,7 +4,7 @@ open MyNat
 /-!
 # Addition World
 
-## Level 2: `add_assoc` -- associativity of addition.
+## Level 2: `add_assoc` -- associativity of addition
 
 It's well-known that (1 + 2) + 3 = 1 + (2 + 3) -- if you have three numbers
 to add up, it doesn't matter which of the additions you do first. This fact
@@ -22,11 +22,11 @@ in explicitly.
 Reminder: you are done when you see "Goals accomplished 🎉" in the InfoView, and no
 errors in the VS Code Problems list.
 
-**Lemma**
+## Lemma
 
 On the set of natural numbers, addition is associative.
-In other words, for all natural numbers `a, b` and `c`, we have
-` (a + b) + c = a + (b + c). `
+In other words, for all natural numbers `a` , `b` and `c`, we have
+`(a + b) + c = a + (b + c)`.
 -/
 
 lemma add_assoc (a b c : MyNat) : (a + b) + c = a + (b + c) := by

--- a/NaturalNumbers/AdditionWorld/Level3.lean
+++ b/NaturalNumbers/AdditionWorld/Level3.lean
@@ -11,7 +11,7 @@ is the proof that `(succ a) + b = succ (a + b)` for `a` and `b` in your
 natural number type. You need to prove this now, because you will need
 to use this result in our proof that `a + b = b + a` in the next level.
 
-Think about why computer scientists called this result `succ_add` .
+Think about why computer scientists called this result `succ_add`.
 There is a logic to all the names.
 
 Note that if you want to be more precise about exactly where you want
@@ -23,9 +23,9 @@ is a function -- it takes as input two variables `a` and `b` and outputs a proof
 that `a + succ b = succ (a + b)`. The tactic `rw [add_succ]` just says to Lean "guess
 what the variables are".
 
-**Lemma**
+## Lemma
 
-For all natural numbers `a` and `b`, we have ` (succ a) + b = succ (a + b). `
+For all natural numbers `a` and `b`, we have ` (succ a) + b = succ (a + b)`.
 -/
 lemma succ_add (a b : MyNat) : succ a + b = succ (a + b) := by
   induction b with

--- a/NaturalNumbers/AdditionWorld/Level3.lean
+++ b/NaturalNumbers/AdditionWorld/Level3.lean
@@ -25,7 +25,7 @@ what the variables are".
 
 **Lemma**
 
-For all natural numbers `a, b`, we have ` (succ a) + b = succ (a + b). `
+For all natural numbers `a` and `b`, we have ` (succ a) + b = succ (a + b). `
 -/
 lemma succ_add (a b : MyNat) : succ a + b = succ (a + b) := by
   induction b with

--- a/NaturalNumbers/AdditionWorld/Level4.lean
+++ b/NaturalNumbers/AdditionWorld/Level4.lean
@@ -14,7 +14,7 @@ In this level, you'll prove that addition is commutative.
 ## Lemma
 
 On the set of natural numbers, addition is commutative.
-In other words, for all natural numbers `a` and `b`, we have `a + b = b + a.`
+In other words, for all natural numbers `a` and `b`, we have `a + b = b + a`.
 -/
 lemma add_comm (a b : MyNat) : a + b = b + a := by
   induction b with

--- a/NaturalNumbers/AdditionWorld/Level5.lean
+++ b/NaturalNumbers/AdditionWorld/Level5.lean
@@ -11,7 +11,7 @@ axiom one_eq_succ_zero : (1 : MyNat) = MyNat.succ 0
 /-!
 We've just added `one_eq_succ_zero` (a statement that `1 = succ 0`).
 This is not a proof it is an axiom.  In Lean an `axiom` tells Lean
-don't both looking for a proof for this fact, just trust me, it's true.
+don't go looking for a proof for this fact, just trust me, it's true.
 So you must be very careful in how you use `axiom` because it can
 lead to inconsistencies in subsequent proofs if your axiom contains
 an error.

--- a/NaturalNumbers/AdditionWorld/Level5.lean
+++ b/NaturalNumbers/AdditionWorld/Level5.lean
@@ -26,7 +26,7 @@ no theorems at all which mention `1`. Let's prove one now.
 
 ## Theorem
 
-For any natural number `n`, we have `succ n = n + 1.`
+For any natural number `n`, we have `succ n = n + 1`.
 -/
 theorem succ_eq_add_one (n : MyNat) : succ n = n + 1 := by
   rw [one_eq_succ_zero]

--- a/NaturalNumbers/AdditionWorld/Level6.lean
+++ b/NaturalNumbers/AdditionWorld/Level6.lean
@@ -22,8 +22,8 @@ If you hadn't picked up on this already, `rw [add_assoc]` will
 change `(x + y) + z` to `x + (y + z)`, but to change it back
 you will need `rw [← add_assoc]`. Get the left arrow by typing `\l`
 then the space bar (note that this is L for left, not a number 1).
-Similarly, if `h : a = b` then `rw [h]` will change `a`'s to `b`'s
-and `rw [← h]` will change `b`'s to `a`'s.
+Similarly, if `h : a = b` then `rw [h]` will change `a`s to `b`s
+and `rw [← h]` will change `b`s to `a`s.
 
 Also, you can be (and will need to be, in this level) more precise
 about where to rewrite theorems. `rw [add_comm]` will just find the
@@ -45,7 +45,7 @@ to some players, are mentioned below the lemma.
 
 ## Lemma
 
-For all natural numbers `a, b` and `c`, we have `a + b + c = a + c + b.`
+For all natural numbers `a, b` and `c`, we have `a + b + c = a + c + b`.
 -/
 lemma add_right_comm (a b c : MyNat) : a + b + c = a + c + b := by
   rw [add_assoc]

--- a/NaturalNumbers/AdvancedAdditionWorld.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld.lean
@@ -12,7 +12,7 @@ import AdvancedAdditionWorld.Level11
 import AdvancedAdditionWorld.Level12
 import AdvancedAdditionWorld.Level13
 /-!
-# Advanced Addition World.
+# Advanced Addition World
 
 Peano's original collection of axioms for the natural numbers contained two further
 assumptions, which have not yet been mentioned in the tutorial:
@@ -31,6 +31,6 @@ For `zero_ne_succ` the trick is that `X ≠ Y` is *defined to mean* `X = Y ⟹ f
 understood through [Proposition world](../PropositionWorld.lean.md), you now have the required Lean
 skills (i.e., you know the required tactics) to work with these implications.
 
-Let's dive in: [Level 1](./AdvancedAdditionWorld/Level1.lean.md)
+Let's dive in: [Level 1](./AdvancedAdditionWorld/Level1.lean.md).
 
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level1.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level1.lean
@@ -10,7 +10,7 @@ axiom succ_inj {a b : MyNat} : succ a = succ b → a = b
 
 # Advanced Addition World
 
-## Level 1: `succ_inj`. A function
+## Level 1: `succ_inj`
 
 Let's learn how to use `succ_inj`. You should know a couple of ways to prove the below -- one
 directly using an `exact`, and one which uses an `apply` first. But either way you'll need to use

--- a/NaturalNumbers/AdvancedAdditionWorld/Level1.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level1.lean
@@ -10,7 +10,7 @@ axiom succ_inj {a b : MyNat} : succ a = succ b → a = b
 
 # Advanced Addition World
 
-## Level 1: `succ_inj`. A function.
+## Level 1: `succ_inj`. A function
 
 Let's learn how to use `succ_inj`. You should know a couple of ways to prove the below -- one
 directly using an `exact`, and one which uses an `apply` first. But either way you'll need to use
@@ -28,9 +28,9 @@ theorem succ_inj' {a b : MyNat} (hs : succ a = succ b) :  a = b := by
 
 You can rewrite proofs of *equalities*. If `h : A = B` then `rw [h]` changes `A`s to `B`s.
 But you *cannot rewrite proofs of implications*. `rw [succ_inj]` will *never work*
-because `succ_inj` isn't of the form `A = B`, it's of the form `A⟹ B`. This is one
+because `succ_inj` isn't of the form `A = B`, it's of the form `A ⟹ B`. This is one
 of the most common mistakes I see from beginners. `⟹` and `=` are *two different things*
 and you need to be clear about which one you are using.
 
-Next up [Level 2](./Level2.lean.md)
+Next up [Level 2](./Level2.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level10.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level10.lean
@@ -10,9 +10,9 @@ open MyNat
 
 ## Important: the definition of `≠`
 
-In Lean, `a ≠ b` is *defined to mean* `(a = b) → false`.
+In Lean, `a ≠ b` is *defined to mean* `(a = b) → False`.
 This means that if you see `a ≠ b` you can *literally treat
-it as saying* `(a = b) → false`. Computer scientists would
+it as saying* `(a = b) → False`. Computer scientists would
 say that these two terms are *definitionally equal*.
 
 The following lemma, `a+b=0 ⟹ b=0`, will be useful in [Inequality World](../InequalityWorld.lean.md).
@@ -34,7 +34,7 @@ and then we have two goals, the case `b = 0` (which you can solve easily)
 and the case `b = succ d`, which looks like this:
 
 ```
-a d : MyNat,
+a d : MyNat
 h : a + succ d = 0
 ⊢ succ d = 0
 ```
@@ -47,13 +47,13 @@ First let's see why `h` is impossible. We can
 
 to turn `h` into `h : succ (a + d) = 0`. Because
 `succ_ne_zero (a + d)` is a proof that `succ (a + d) ≠ 0`,
-it is also a proof of the implication `succ (a + d) = 0 → false`.
-Hence `succ_ne_zero (a + d) h` is a proof of `false`!
-Unfortunately our goal is not `false`, it's a generic
+it is also a proof of the implication `succ (a + d) = 0 → False`.
+Hence `succ_ne_zero (a + d) h` is a proof of `False`!
+Unfortunately our goal is not `False`, it's a generic
 false statement.
 
-Recall however that the `exfalso` command turns any goal into `false`
-(it's logically OK because `false` implies every proposition, true or false).
+Recall however that the `exfalso` command turns any goal into `False`
+(it's logically OK because `False` implies every proposition, true or false).
 
 
 ## Lemma
@@ -70,5 +70,5 @@ lemma add_left_eq_zero {{a b : MyNat}} (h : a + b = 0) : b = 0 := by
     exact h
 
 /-!
-Next up [Level 11](./Level11.lean.md)
+Next up [Level 11](./Level11.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level11.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level11.lean
@@ -24,5 +24,5 @@ lemma add_right_eq_zero {a b : MyNat} : a + b = 0 → a = 0 := by
 
 
 /-!
-Next up [Level 12](./Level12.lean.md)
+Next up [Level 12](./Level12.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level12.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level12.lean
@@ -17,7 +17,7 @@ We have
 but sometimes the other way is also convenient.
 
 ## Theorem
-For any natural number `d`, we have ` d+1 = succ d`.
+For any natural number `d`, we have `d+1 = succ d`.
 -/
 theorem add_one_eq_succ (d : MyNat) : d + 1 = succ d := by
   rw [succ_eq_add_one]

--- a/NaturalNumbers/AdvancedAdditionWorld/Level12.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level12.lean
@@ -17,11 +17,11 @@ We have
 but sometimes the other way is also convenient.
 
 ## Theorem
-For any natural number `d`, we have ` d+1 = succ d. `
+For any natural number `d`, we have ` d+1 = succ d`.
 -/
 theorem add_one_eq_succ (d : MyNat) : d + 1 = succ d := by
   rw [succ_eq_add_one]
 
 /-!
-Next up [Level 13](./Level13.lean.md)
+Next up [Level 13](./Level13.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level13.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level13.lean
@@ -15,7 +15,7 @@ The last level in Advanced Addition World is the statement
 that `n ≠ succ n`.
 
 ## Lemma
-For any natural number `n`, we have ` n ≠ succ n`.
+For any natural number `n`, we have `n ≠ succ n`.
 -/
 lemma ne_succ_self (n : MyNat) : n ≠ succ n := by
   induction n with
@@ -28,7 +28,7 @@ lemma ne_succ_self (n : MyNat) : n ≠ succ n := by
     assumption
 
 /-!
-Well that's a wrap on Advanced Addition World !
+Well that's a wrap on Advanced Addition World!
 
 You can now move on to Advanced Multiplication World
 (after first doing [Multiplication World](../MultiplicationWorld.lean.md), if you didn't do it already).

--- a/NaturalNumbers/AdvancedAdditionWorld/Level2.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level2.lean
@@ -41,5 +41,5 @@ example {a b : MyNat} (h : succ (succ a) = succ (succ b)) :  a = b := by
   exact succ_inj (succ_inj h)
 
 /-!
-Next up [Level 3](./Level3.lean.md)
+Next up [Level 3](./Level3.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level3.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level3.lean
@@ -7,7 +7,7 @@ open MyNat
 
 # Advanced Addition World
 
-## Level 3: `succ_eq_succ_of_eq`.
+## Level 3: `succ_eq_succ_of_eq`
 
 We are going to prove something completely obvious: if `a=b` then
 `succ a = succ b`. This is *not* `succ_inj`!
@@ -22,5 +22,5 @@ theorem succ_eq_succ_of_eq {a b : MyNat} : a = b → succ a = succ b := by
   rw [h]
 
 /-!
-Next up [Level 4](./Level4.lean.md)
+Next up [Level 4](./Level4.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level4.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level4.lean
@@ -24,7 +24,7 @@ it with
 
 and the second one you could solve by looking up the name of the theorem
 you proved in the last level and doing `exact <that name>`, or alternatively
-you could get some more `intro` practice and seeing if you can prove it
+you could get some more `intro` practice and see if you can prove it
 using `intro` and `rw`.
 
 Remember that `succ_inj` is `succ a = succ b → a = b`.
@@ -39,5 +39,5 @@ theorem succ_eq_succ_iff (a b : MyNat) : succ a = succ b ↔ a = b := by
 
 
 /-!
-Next up [Level 5](./Level5.lean.md)
+Next up [Level 5](./Level5.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level5.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level5.lean
@@ -17,8 +17,8 @@ to do rewriting of hypotheses rather than the goal.
 
 ## Theorem
 On the set of natural numbers, addition has the right cancellation property.
-In other words, if there are natural numbers `a, b` and `c` such that
-` a + t = b + t ` then we have `a = b`.
+In other words, if there are natural numbers `a`, `b` and `c` such that
+`a + t = b + t` then we have `a = b`.
 -/
 theorem add_right_cancel (a t b : MyNat) : a + t = b + t → a = b := by
   intro h
@@ -35,5 +35,5 @@ theorem add_right_cancel (a t b : MyNat) : a + t = b + t → a = b := by
     exact succ_inj h
 
 /-!
-Next up [Level 6](./Level6.lean.md)
+Next up [Level 6](./Level6.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level6.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level6.lean
@@ -28,5 +28,5 @@ theorem add_left_cancel (t a b : MyNat) : t + a = t + b → a = b := by
 
 
 /-!
-Next up [Level 7](./Level7.lean.md)
+Next up [Level 7](./Level7.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level7.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level7.lean
@@ -20,7 +20,7 @@ Notice `exact add_right_cancel _ _ _` means "let Lean figure out the missing inp
 so we don't have to spell it out like we did in Level 6.
 
 ## Theorem
-For all naturals `a`, `b` and `t`, `a + t = b + t ↔ a = b.`
+For all naturals `a`, `b` and `t`, `a + t = b + t ↔ a = b`.
 -/
 theorem add_right_cancel_iff (t a b : MyNat) :  a + t = b + t ↔ a = b := by
   constructor

--- a/NaturalNumbers/AdvancedAdditionWorld/Level7.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level7.lean
@@ -29,5 +29,5 @@ theorem add_right_cancel_iff (t a b : MyNat) :  a + t = b + t ↔ a = b := by
   rw [h]
 
 /-!
-Next up [Level 8](./Level8.lean.md)
+Next up [Level 8](./Level8.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level8.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level8.lean
@@ -16,7 +16,7 @@ There are some wrong paths that you can take with this one.
 ## Lemma
 
 If `a` and `b` are natural numbers such that
-` a + b = a, ` then `b = 0`.
+`a + b = a`, then `b = 0`.
 -/
 
 lemma eq_zero_of_add_right_eq_self {a b : MyNat} : a + b = a → b = 0 := by
@@ -26,12 +26,12 @@ lemma eq_zero_of_add_right_eq_self {a b : MyNat} : a + b = a → b = 0 := by
   rw [add_zero]
 
 /-!
-Remember from [FunctionWorld Level 4]()../FunctonWorld/Level4.lean.md) that the
-`apply` tactic is can construct the path backwards?  Well when we use it with
+Remember from [FunctionWorld Level 4](../FunctonWorld/Level4.lean.md) that the
+`apply` tactic can construct the path backwards?  Well when we use it with
 `add_left_cancel a` it results in the opposite of cancellation, it
 results in _adding a to both sides_ changing the goal from `⊢ b = 0`
 to `⊢ a + b = a + 0`.  This then allows us to use our hypothesis `h : a + b = a`
 in `rw` to complete the proof.
 
-Next up [Level 9](./Level9.lean.md)
+Next up [Level 9](./Level9.lean.md).
 -/

--- a/NaturalNumbers/AdvancedAdditionWorld/Level9.lean
+++ b/NaturalNumbers/AdvancedAdditionWorld/Level9.lean
@@ -47,5 +47,5 @@ theorem succ_ne_zero (a : MyNat) : succ a ≠ 0 := by
   apply (zero_ne_succ a)
 
 /-!
-Next up [Level 10](./Level10.lean.md)
+Next up [Level 10](./Level10.lean.md).
 -/

--- a/NaturalNumbers/AdvancedMultiplicationWorld.Lean
+++ b/NaturalNumbers/AdvancedMultiplicationWorld.Lean
@@ -11,5 +11,5 @@ world you should have completed seven other worlds, including
 [Advanced Addition World](./AdvancedAdditionWorld.lean.md).
 There are four levels in this world.
 
-Let's dive in [Level 1](./AdvancedMultiplicationWorld/Level1.lean.md)
+Let's dive in [Level 1](./AdvancedMultiplicationWorld/Level1.lean.md).
 -/

--- a/NaturalNumbers/AdvancedMultiplicationWorld/Level1.lean
+++ b/NaturalNumbers/AdvancedMultiplicationWorld/Level1.lean
@@ -17,11 +17,11 @@ a weaker version of induction (you don't get the inductive hypothesis).
 ## Tricks
 
 1) if your goal is `⊢ X ≠ Y` then `intro h` will give you `h : X = Y` and
-a goal of `⊢ false`. This is because `X ≠ Y` *means* `(X = Y) → false`.
-Conversely if your goal is `false` and you have `h : X ≠ Y` as a hypothesis
+a goal of `⊢ False`. This is because `X ≠ Y` *means* `(X = Y) → False`.
+Conversely if your goal is `False` and you have `h : X ≠ Y` as a hypothesis
 then `apply h` will work backwards and turn the goal into `X = Y`.
 
-2) if `hab : succ (3 * x + 2 * y + 1) = 0` is a hypothesis and your goal is `⊢ false`,
+2) if `hab : succ (3 * x + 2 * y + 1) = 0` is a hypothesis and your goal is `⊢ False`,
 then `exact succ_ne_zero _ hab` will solve the goal, because Lean will figure
 out that `_` is supposed to be `3 * x + 2 * y + 1`.
 
@@ -47,5 +47,5 @@ theorem mul_pos (a b : MyNat) : a ≠ 0 → b ≠ 0 → a * b ≠ 0 := by
       exact succ_ne_zero _ hab
 /-!
 
-Next up [Level 2](./Level2.lean.md)
+Next up [Level 2](./Level2.lean.md).
 -/

--- a/NaturalNumbers/AdvancedMultiplicationWorld/Level2.lean
+++ b/NaturalNumbers/AdvancedMultiplicationWorld/Level2.lean
@@ -34,5 +34,5 @@ theorem eq_zero_or_eq_zero_of_mul_eq_zero (a b : MyNat) (h : a * b = 0) :
       exact succ_ne_zero _ h
 /-!
 
-Next up [Level 3](./Level3.lean.md)
+Next up [Level 3](./Level3.lean.md).
 -/

--- a/NaturalNumbers/AdvancedMultiplicationWorld/Level3.lean
+++ b/NaturalNumbers/AdvancedMultiplicationWorld/Level3.lean
@@ -13,7 +13,7 @@ open MyNat
 Now you have `eq_zero_or_eq_zero_of_mul_eq_zero` this is pretty straightforward.
 
 ## Theorem
-`ab = 0`, if and only if at least one of `a` or `b` is equal to zero.
+`ab = 0` if and only if at least one of `a` or `b` is equal to zero.
 -/
 theorem mul_eq_zero_iff (a b : MyNat): a * b = 0 ↔ a = 0 ∨ b = 0 := by
   constructor
@@ -34,5 +34,5 @@ theorem mul_eq_zero_iff (a b : MyNat): a * b = 0 ↔ a = 0 ∨ b = 0 := by
 
 /-!
 
-Next up [Level 4](./Level4.lean.md)
+Next up [Level 4](./Level4.lean.md).
 -/

--- a/NaturalNumbers/AdvancedMultiplicationWorld/Level4.lean
+++ b/NaturalNumbers/AdvancedMultiplicationWorld/Level4.lean
@@ -14,7 +14,7 @@ This is the last of the bonus multiplication levels. `mul_left_cancel` will be u
 world.
 
 People find this level hard. I have probably had more questions about this level than all the other
-levels put together, in fact. Many levels in this game can just be solved by "running at it" -- do
+levels put together. Many levels in this game can just be solved by "running at it" -- do
 induction on one of the variables, keep your head, and you're done. In fact, if you like a
 challenge, it might be instructive if you stop reading after the end of this paragraph and try
 solving this level now by induction, seeing the trouble you run into, and reading the rest of these
@@ -44,7 +44,7 @@ If you do not modify your technique in this way, then this level seems
 to be impossible (judging by the comments I've had about it!)
 
 ## Theorem
-If `a ≠ 0`, `b` and `c` are natural numbers such that ` ab = ac, ` then `b = c`.
+If `a ≠ 0`, `b` and `c` are natural numbers such that `ab = ac`, then `b = c`.
 -/
 
 set_option trace.Meta.Tactic.simp true

--- a/NaturalNumbers/AdvancedPropositionWorld.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld.lean
@@ -9,13 +9,13 @@ import AdvancedPropositionWorld.Level8
 import AdvancedPropositionWorld.Level9
 import AdvancedPropositionWorld.Level10
 /-!
-# Advanced proposition world.
+# Advanced Proposition World
 
 In this world we will learn six key tactics needed to solve all the
 levels of this world, namely `constructor`, `cases`, `rcases`, `left`, `right`, and `exfalso`.
 These, and `use` (which we'll get to in [Inequality World](../InequalityWorld.lean.md)) are all the
 tactics you will need to understand all the levels of the tutorial.
 
-Let's dive in: [Level 1](./AdvancedPropositionWorld/Level1.lean.md)
+Let's dive in: [Level 1](./AdvancedPropositionWorld/Level1.lean.md).
 
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level1.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level1.lean
@@ -7,7 +7,7 @@ open MyNat
 ## Level 1: the `constructor` tactic
 
 The logical symbol `∧` means "and". If `P` and `Q` are propositions, then `P ∧ Q` is the proposition
-"`P` and `Q`". If your *goal* is `P ∧ Q` then you can make progress with the [`constructor` tactic](../Tactics/constructor.lean.md).,
+"`P` and `Q`". If your *goal* is `P ∧ Q` then you can make progress with the [`constructor` tactic](../Tactics/constructor.lean.md),
 which turns one goal `⊢ P ∧ Q` into two goals, namely `⊢ P` and `⊢ Q`. In the level below, after a
 `constructor`, you can finish off the two new sub-goals with the `exact` tactic since both `p` and
 `q` provide exactly what we need.  You could also use the `assumption` tactic.

--- a/NaturalNumbers/AdvancedPropositionWorld/Level1.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level1.lean
@@ -2,9 +2,9 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Advanced Proposition world
+# Advanced Proposition World
 
-## Level 1: the `constructor` tactic.
+## Level 1: the `constructor` tactic
 
 The logical symbol `∧` means "and". If `P` and `Q` are propositions, then `P ∧ Q` is the proposition
 "`P` and `Q`". If your *goal* is `P ∧ Q` then you can make progress with the [`constructor` tactic](../Tactics/constructor.lean.md).,
@@ -22,5 +22,5 @@ example (P Q : Prop) (p : P) (q : Q) : P ∧ Q := by
 /-!
 
 
-Next up [Level 2](./Level2.lean.md)
+Next up [Level 2](./Level2.lean.md).
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level10.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level10.lean
@@ -2,9 +2,9 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Advanced proposition world.
+# Advanced Proposition World
 
-## Level 10: the law of the excluded middle.
+## Level 10: the law of the excluded middle
 
 We proved earlier that `(P → Q) → (¬ Q → ¬ P)`. The converse,
 that `(¬ Q → ¬ P) → (P → Q)` is certainly true, but trying to prove
@@ -19,8 +19,8 @@ repeat rw [not_iff_imp_false] at h
 
 in the below, you are left with
 ```
-P Q : Prop,
-h : (Q → false) → P → false
+P Q : Prop
+h : (Q → False) → P → False
 p : P
 ⊢ Q
 ```
@@ -33,8 +33,8 @@ goal of `⊢ Q`.  But how can you prove `Q` using these hypotheses?  You can use
 `by_cases q : Q`
 
 This creates two sub-goals `pos` and `neg` with the first one assuming Q is true - which can easily
-satisfy the goal! and the second one assuming Q is false. But how can `h: ¬Q → ¬P`, `p: P`, `q: ¬Q`
-prove the goal `⊢ Q` ? Well if you apply `q` to the hypothesis `h` you end up with the conclusion
+satisfy the goal! - and the second one assuming Q is false. But how can `h: ¬Q → ¬P`, `p: P`, `q: ¬Q`
+prove the goal `⊢ Q`? Well if you apply `q` to the hypothesis `h` you end up with the conclusion
 `¬ P`, but then you have a contradiction in your hypotheses saying `P` and `¬ P` which the
 [`contradiction` tactic](../Tactics/contradiction.lean.md) can take care of.
 

--- a/NaturalNumbers/AdvancedPropositionWorld/Level10.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level10.lean
@@ -17,7 +17,7 @@ intro p
 repeat rw [not_iff_imp_false] at h
 ```
 
-in the below, you are left with
+below you are left with
 ```
 P Q : Prop
 h : (Q → False) → P → False
@@ -27,7 +27,7 @@ p : P
 
 The tools you have are not sufficient to continue. But you can just prove this, and any other basic
 lemmas of this form like `¬ ¬ P → P`, using the [`by_cases` tactic](../Tactics/by_cases.lean.md). Here we start with the usual
-`intros` to turn the implication into hypotheses `h : ¬ Q → ¬ P` and `p : P` which leaves with the
+`intro` to turn the implication into hypotheses `h : ¬ Q → ¬ P` and `p : P` which leaves with the
 goal of `⊢ Q`.  But how can you prove `Q` using these hypotheses?  You can use this tactic:
 
 `by_cases q : Q`
@@ -42,8 +42,7 @@ The `contradiction` tactic closes the main goal if its hypotheses
 are "trivially contradictory".
 
 ## Lemma
-If `P` and `Q` are true/false statements, then
-`(¬ Q ⟹ ¬ P) ⟹ (P ⟹ Q).`
+If `P` and `Q` are true/false statements, then `(¬ Q ⟹ ¬ P) ⟹ (P ⟹ Q)`.
 -/
 lemma contrapositive2 (P Q : Prop) : (¬ Q → ¬ P) → (P → Q) := by
   intro h

--- a/NaturalNumbers/AdvancedPropositionWorld/Level2.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level2.lean
@@ -23,7 +23,7 @@ is a hypothesis, and we can extract the parts of this `And.intro` using the [`ca
 
 This will give us two hypotheses `p` and `q` proving `P` and `Q` respectively.  So we hold onto
 these, the goal is now `⊢ Q ∧ P` which we can split using the `constructor` tactic, then we can
-easily pick off the two sub-goals `⊢ Q` and  `⊢ P` using `q` and `p` respectively.
+easily pick off the two sub-goals `⊢ Q` and `⊢ P` using `q` and `p` respectively.
 
 ## Lemma
 If `P` and `Q` are true/false statements, then `P ∧ Q ⟹ Q ∧ P`.

--- a/NaturalNumbers/AdvancedPropositionWorld/Level2.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level2.lean
@@ -4,9 +4,9 @@ open MyNat
 /-!
 
 
-# Advanced proposition world.
+# Advanced Proposition World
 
-## Level 2: the `cases` tactic.
+## Level 2: the `cases` tactic
 
 If `P ∧ Q` is in the goal, then we can make progress with `constructor`. But what if `P ∧ Q` is a
 hypothesis?
@@ -39,5 +39,5 @@ lemma and_symm (P Q : Prop) : P ∧ Q → Q ∧ P := by
 /-!
 
 
-Next up [Level 3](./Level3.lean.md)
+Next up [Level 3](./Level3.lean.md).
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level3.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level3.lean
@@ -2,11 +2,11 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Advanced proposition world.
+# Advanced Proposition World
 
-## Level 3: and_trans.
+## Level 3: and_trans
 
-With this proof we can use the first `cases` tactic to extract hypotheses `p : P` `q : Q` from
+With this proof we can use the first `cases` tactic to extract hypotheses `p : P` and `q : Q` from
 `hpq : P ∧ Q` and then we can use another `cases` tactic to extract hypotheses `q' : Q` and `r : R` from
 `hpr : Q ∧ R` then we can split the resulting goal `⊢ P ∧ R` using `constructor` and easily pick off the
 resulting sub-goals `⊢ P` and `⊢ R` using our given hypotheses.
@@ -28,5 +28,5 @@ lemma and_trans (P Q R : Prop) : P ∧ Q → Q ∧ R → P ∧ R := by
 
 /-!
 
-Next up [Level 4](./Level4.lean.md)
+Next up [Level 4](./Level4.lean.md).
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level3.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level3.lean
@@ -4,7 +4,7 @@ open MyNat
 /-!
 # Advanced Proposition World
 
-## Level 3: and_trans
+## Level 3: `and_trans`
 
 With this proof we can use the first `cases` tactic to extract hypotheses `p : P` and `q : Q` from
 `hpq : P ∧ Q` and then we can use another `cases` tactic to extract hypotheses `q' : Q` and `r : R` from

--- a/NaturalNumbers/AdvancedPropositionWorld/Level4.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level4.lean
@@ -3,9 +3,9 @@ namespace MyNat
 open MyNat
 /-!
 
-# Advanced proposition world.
+# Advanced Proposition World
 
-## Level 4: `iff_trans`.
+## Level 4: `iff_trans`
 
 The mathematical statement `P ↔ Q` is equivalent to `(P ⟹ Q) ∧ (Q ⟹ P)`. The `cases`
 and `split` tactics work on hypotheses and goals (respectively) of the form `P ↔ Q`.
@@ -41,5 +41,5 @@ lemma iff_trans (P Q R : Prop) : (P ↔ Q) → (Q ↔ R) → (P ↔ R) := by
 /-!
 
 
-Next up [Level 5](./Level5.lean.md)
+Next up [Level 5](./Level5.lean.md).
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level5.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level5.lean
@@ -9,7 +9,7 @@ open MyNat
 
 Let's try `iff_trans` again. Try proving it in other ways.
 
-### A trick.
+### A trick
 
 Instead of using `cases` on `h : P ↔ Q` you can just access the proofs of `P → Q` and `Q → P`
 directly with `h.mp` and `h.mpr`.

--- a/NaturalNumbers/AdvancedPropositionWorld/Level5.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level5.lean
@@ -3,9 +3,9 @@ namespace MyNat
 open MyNat
 /-!
 
-# Advanced proposition world.
+# Advanced Proposition World
 
-## Level 5: `iff_trans` easter eggs.
+## Level 5: `iff_trans` easter eggs
 
 Let's try `iff_trans` again. Try proving it in other ways.
 
@@ -48,5 +48,5 @@ lemma iff_trans₃ (P Q R : Prop) : (P ↔ Q) → (Q ↔ R) → (P ↔ R) := by
 /-!
 
 
-Next up [Level 6](./Level6.lean.md)
+Next up [Level 6](./Level6.lean.md).
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level6.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level6.lean
@@ -1,8 +1,8 @@
 import Mathlib.Tactic.LeftRight
 /-!
-# Advanced proposition world.
+# Advanced Proposition World
 
-## Level 6: Or, and the [`left` and `right` tactics](../Tactics/leftright.lean.md).
+## Level 6: Or, and the [`left` and `right` tactics](../Tactics/leftright.lean.md)
 
 `P ∨ Q` means "`P` or `Q`". So to prove it, you need to choose one of `P` or `Q`, and prove that
 one. If `⊢ P ∨ Q` is your goal, then `left` changes this goal to `⊢ P`, and `right` changes it to `⊢ Q`.
@@ -10,7 +10,7 @@ Note that you can take a wrong turn here. Let's start with trying to prove `Q �
 the `intro`, one of `left` and `right` leads to an impossible goal, the other to an easy finish.
 
 ## Lemma
-If `P` and `Q` are true/false statements, then `Q ⟹(P ∨ Q).`
+If `P` and `Q` are true/false statements, then `Q ⟹(P ∨ Q)`.
 -/
 example (P Q : Prop) : Q → (P ∨ Q) := by
   intro q
@@ -41,5 +41,5 @@ require mathlib from git
 This specifies a precise version of mathlib4 by commit Id.
 
 
-Next up [Level 7](./Level7.lean.md)
+Next up [Level 7](./Level7.lean.md).
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level7.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level7.lean
@@ -2,7 +2,7 @@ import Mathlib.Tactic.LeftRight
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Cases
 /-!
-# Advanced proposition world.
+# Advanced Proposition World
 
 ## Level 7: `or_symm`
 
@@ -14,7 +14,7 @@ happens: because there are two ways to prove `P ∨ Q` (namely, proving `P` or p
 using the `left` and `right` tactics we used in [Level 6](./Level6.lean.md).
 
 ## Lemma
-If `P` and `Q` are true/false statements, then `P ∨ Q ⟹ Q ∨ P.`
+If `P` and `Q` are true/false statements, then `P ∨ Q ⟹ Q ∨ P`.
 -/
 lemma or_symm (P Q : Prop) : P ∨ Q → Q ∨ P := by
   intro h
@@ -29,5 +29,5 @@ lemma or_symm (P Q : Prop) : P ∨ Q → Q ∨ P := by
 /-!
 
 
-Next up [Level 8](./Level8.lean.md)
+Next up [Level 8](./Level8.lean.md).
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level8.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level8.lean
@@ -12,9 +12,9 @@ over `∧`. Let's prove one of these.
 
 Some new tactics are handy here, the `rintro` tactic is a combination of the `intro` tactic with
 `rcases` to allow for destructuring patterns while introducing variables. For example,
-`rintro ⟨HP, HQ | HR⟩` below matches the subgoal `P ∧ (Q ∨ R)` and introduces the new hypothesis
-`HP : P` and breaks the Or `Q ∨ R` into two left and right sub-goals each with
-hypothesis `HQ : Q` and `HR : R`.
+`rintro ⟨HP, HQ | HR⟩` below matches the subgoal `P ∧ (Q ∨ R)`, introduces the new hypothesis
+`HP : P`, and breaks `Q ∨ R` into a left subgoal with hypothesis `HQ : Q` and a right sub-goal with
+hypothesis`HR : R`.
 
 Notice here that you can use a semi-colon to separate multiple tactics on the same line. Another
 trick shown below is the [<;> tactic](../Tactics/concatenate.lean.md). We could have written `left; constructor; assumption; assumption`
@@ -23,7 +23,7 @@ can just write `<;> assumption` which runs `assumption` on both sub-goals.
 
 ## Lemma
 If `P`, `Q` and `R` are true/false statements, then
-`P ∧ (Q ∨ R) ↔ (P ∧ Q) ∨ (P ∧ R).`
+`P ∧ (Q ∨ R) ↔ (P ∧ Q) ∨ (P ∧ R)`.
 -/
 lemma and_or_distrib_left (P Q R : Prop) : P ∧ (Q ∨ R) ↔ (P ∧ Q) ∨ (P ∧ R) := by
   constructor

--- a/NaturalNumbers/AdvancedPropositionWorld/Level8.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level8.lean
@@ -2,7 +2,7 @@ import Mathlib.Tactic.LeftRight
 import Mathlib.Tactic.Basic
 import Std.Tactic.RCases
 /-!
-# Advanced proposition world.
+# Advanced Proposition World
 
 ## Level 8: `and_or_distrib_left`
 
@@ -10,7 +10,7 @@ We know that `x(y+z)=xy+xz` for numbers, and this is called distributivity of mu
 addition. The same is true for `∧` and `∨` -- in fact `∧` distributes over `∨` and `∨` distributes
 over `∧`. Let's prove one of these.
 
-Some new tactics are handy here, the `rintro` tactic is a combination of the `intros` tactic with
+Some new tactics are handy here, the `rintro` tactic is a combination of the `intro` tactic with
 `rcases` to allow for destructuring patterns while introducing variables. For example,
 `rintro ⟨HP, HQ | HR⟩` below matches the subgoal `P ∧ (Q ∨ R)` and introduces the new hypothesis
 `HP : P` and breaks the Or `Q ∨ R` into two left and right sub-goals each with
@@ -22,7 +22,7 @@ since the `constructor` produces two sub-goals we need 2 `assumption` tactics to
 can just write `<;> assumption` which runs `assumption` on both sub-goals.
 
 ## Lemma
-If `P`. `Q` and `R` are true/false statements, then
+If `P`, `Q` and `R` are true/false statements, then
 `P ∧ (Q ∨ R) ↔ (P ∧ Q) ∨ (P ∧ R).`
 -/
 lemma and_or_distrib_left (P Q R : Prop) : P ∧ (Q ∨ R) ↔ (P ∧ Q) ∨ (P ∧ R) := by
@@ -60,5 +60,5 @@ then runs tacs. If the resulting goal state is not [], throw an error.
 Then restore the remaining goals [g2, ..., gn].
 
 
-Next up [Level 9](./Level9.lean.md)
+Next up [Level 9](./Level9.lean.md).
 -/

--- a/NaturalNumbers/AdvancedPropositionWorld/Level9.lean
+++ b/NaturalNumbers/AdvancedPropositionWorld/Level9.lean
@@ -4,22 +4,22 @@ import Lean.Meta.Tactic.Apply
 import Lean.Meta.Tactic.Cases
 import PropositionWorld.Level8 -- not_iff_imp_false
 /-!
-# Advanced proposition world.
+# Advanced Proposition World
 
 You already know enough to embark on advanced addition world. But here are just a couple
 more things.
 
-## Level 9: `exfalso` and proof by contradiction.
+## Level 9: `exfalso` and proof by contradiction
 
 It's certainly true that `P ∧ (¬ P) ⟹ Q` for any propositions `P`
 and `Q`, because the left hand side of the implication is false. But how do
-we prove that `false` implies any proposition `Q`? A cheap way of doing it in
-Lean is using the [`exfalso` tactic](../Tactics/exfalso.lean.md), which changes any goal at all to `false`.
+we prove that `False` implies any proposition `Q`? A cheap way of doing it in
+Lean is using the [`exfalso` tactic](../Tactics/exfalso.lean.md), which changes any goal at all to `False`.
 You might think this is a step backwards, but if you have a hypothesis `h : ¬ P`
-then after `rw not_iff_imp_false at h,` you can `apply h,` to make progress.
+then after `rw not_iff_imp_false at h` you can `apply h` to make progress.
 
 ## Lemma
-If `P` and `Q` are true/false statements, then `(P ∧ (¬ P)) ⟹ Q.`
+If `P` and `Q` are true/false statements, then `(P ∧ (¬ P)) ⟹ Q`.
 -/
 lemma contra (P Q : Prop) : (P ∧ ¬ P) → Q := by
   intro h
@@ -33,10 +33,10 @@ lemma contra (P Q : Prop) : (P ∧ ¬ P) → Q := by
 /-!
 ## Pro tip.
 
-`¬ P` is actually `P → false` *by definition* and since `np: ¬ P` is a hypothesis,
+`¬ P` is actually `P → False` *by definition* and since `np: ¬ P` is a hypothesis,
 `apply q` changes `⊢ False` to `⊢ P`.  Neat trick.  We started with `⊢ Q`, but
 could not prove it so we jumped to `False` so we could use `np: ¬ P` to get to
 the desired goal `⊢ P`.
 
-Next up [Level 10](./Level10.lean.md)
+Next up [Level 10](./Level10.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld.lean
+++ b/NaturalNumbers/FunctionWorld.lean
@@ -37,12 +37,11 @@ been writing `n : MyNat` to mean that `n` is a natural number.
 All through addition world, our goals have been theorems,
 and it was our job to find the proofs.
 **The levels in function world aren't theorems**. This is the only world where
-the levels aren't theorems in fact. In function world the object of a level
+the levels aren't theorems. In function world the object of a level
 is to create an element of the set in the goal. The goal will look like `⊢ X`
 with `X` a set and you get rid of the goal by constructing an element of `X`.
 I don't know if you noticed this, but you finished
-essentially every goal of Addition World (and Multiplication World and Power World,
-) with `rfl` or the implied `rfl` performed by `rw`.
+essentially every goal of Addition World (and Multiplication World and Power World) with `rfl` or the implied `rfl` performed by `rw`.
 This tactic is no use to us here.
 We are going to have to learn a new way of solving goals &ndash; the `exact` tactic.
 

--- a/NaturalNumbers/FunctionWorld/Level1.lean
+++ b/NaturalNumbers/FunctionWorld/Level1.lean
@@ -5,7 +5,7 @@ open MyNat
 /-!
 # Function World
 
-## Level 1: the `exact` tactic.
+## Level 1: the `exact` tactic
 
 Given an element of `P` and a function from `P` to `Q`,
 we define an element of `Q`.
@@ -21,8 +21,8 @@ If you place your cursor at the end of the `example` line above
 the tactic state will look like this:
 
 ```
-P Q : Type,
-p : P,
+P Q : Type
+p : P
 h : P → Q
 ⊢ Q
 ```
@@ -66,8 +66,8 @@ might think of as either sets or propositions),
 and the local context looks like this:
 
 ```
-p : P,
-h : P → Q,
+p : P
+h : P → Q
 j : Q → R
 ⊢ R
 ```
@@ -83,5 +83,5 @@ because `j (h p)` is easily checked to be a term of type `R`
 (i.e., an element of the set `R`, or a proof of the proposition `R`).
 
 
-Next up [Level 2](./Level2.lean.md)
+Next up [Level 2](./Level2.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld/Level2.lean
+++ b/NaturalNumbers/FunctionWorld/Level2.lean
@@ -27,9 +27,7 @@ The Lean tactic for "let `x ∈ X` be arbitrary" is `intro x`.
 If your goal is `P → Q` then `intro p` will make progress.
 
 To solve the goal below, you have to come up with a function from `MyNat`
-to `MyNat`. We can start with `intro n`
-
-(i.e. "let `n ∈ ℕ` be arbitrary") and note that our
+to `MyNat`. We can start with `intro n` (i.e. "let `n ∈ ℕ` be arbitrary") and note that our
 local context now looks like this:
 
 ```
@@ -57,7 +55,7 @@ example : MyNat → MyNat := by
 You can hover your mouse over the tactics `intro` and `exact`
 to the documentation on these tactics in case you need a
 reminder later on.
-See also [intro tactic](../Tactics/intro.lean.md)
+See also [intro tactic](../Tactics/intro.lean.md).
 
 
 Next up [Level 3](./Level3.lean.md).

--- a/NaturalNumbers/FunctionWorld/Level2.lean
+++ b/NaturalNumbers/FunctionWorld/Level2.lean
@@ -60,5 +60,5 @@ reminder later on.
 See also [intro tactic](../Tactics/intro.lean.md)
 
 
-Next up [Level 3](./Level3.lean.md)
+Next up [Level 3](./Level3.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld/Level3.lean
+++ b/NaturalNumbers/FunctionWorld/Level3.lean
@@ -5,7 +5,7 @@ open MyNat
 /-!
 # Function World
 
-## Level 3: the `have` tactic.
+## Level 3: the `have` tactic
 
 Say you have a whole bunch of sets and functions between them,
 and your goal is to build a certain element of a certain set.
@@ -37,8 +37,8 @@ and then we note that `j q` is an element of `T`
 
 `have t : T := j q`
 
-(notice how on this occasion we explicitly told Lean what set we thought `t` was in, with
-that `: T` thing before the `:=`) and we could even define `u` to be `l t`:
+Notice how on this occasion we explicitly told Lean what set we thought `t` was in, with
+that `: T` thing before the `:=`. We could even define `u` to be `l t`:
 
 `have u : U := l t`
 

--- a/NaturalNumbers/FunctionWorld/Level3.lean
+++ b/NaturalNumbers/FunctionWorld/Level3.lean
@@ -23,7 +23,7 @@ functions looks like this pictorially:
 
 ![diagram](../assets/function_diag.svg)
 
-and so it's clear how to make the element of `U` from the element of `P.`
+and so it's clear how to make the element of `U` from the element of `P`.
 Indeed, we could solve this level in one move by typing
 
 `exact l (j (h p))`
@@ -67,15 +67,15 @@ in this proof in Visual Studio Code, and note that the tactic state at the begin
 this mess:
 
 ```
-P Q R S T U : Type,
-p : P,
-h : P → Q,
-i : Q → R,
-j : Q → T,
-k : S → T,
-l : T → U,
-q : Q,
-t : T,
+P Q R S T U : Type
+p : P
+h : P → Q
+i : Q → R
+j : Q → T
+k : S → T
+l : T → U
+q : Q
+t : T
 u : U
 ⊢ U
 ```
@@ -85,5 +85,5 @@ terms to it. In level 4 we will learn about the `apply` tactic
 which solves the level using another technique, without leaving
 so much junk behind.
 
-Next up [Level 4](./Level4.lean.md)
+Next up [Level 4](./Level4.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld/Level4.lean
+++ b/NaturalNumbers/FunctionWorld/Level4.lean
@@ -11,14 +11,14 @@ Let's do the same level again a different way:
 
 ![diagram](../assets/function_diag.svg)
 
-We are given `p  ∈ P` and our goal is to find an element of `U`, or
+We are given `p ∈ P` and our goal is to find an element of `U`, or
 in other words to find a path through the maze that links `P` to `U`.
 In level 3 we solved this by using `have`s to move forward, from `P`
 to `Q` to `T` to `U`.
 Using the [apply tactic](../Tactics/apply.lean.md) we can instead construct
 the path backwards, moving from `U` to `T` to `Q` to `P`.
 
-Our goal is to construct an element of the set `U`. But `l:T → U` is
+Our goal is to construct an element of the set `U`. But `l : T → U` is
 a function, so it would suffice to construct an element of `T`. Tell
 Lean this by starting the proof below with
 
@@ -31,7 +31,7 @@ Keep `apply`ing functions until your goal is `P`, and try not
 to get lost! Now solve this goal
 with `exact p`. Note: you will need to learn the difference between
 `exact p` (which works) and `exact P` (which doesn't, because `P` is
-not an element of  `P`).
+not an element of `P`).
 
 ## Definition
 Given an element of `P` we can define an element of `U`.

--- a/NaturalNumbers/FunctionWorld/Level4.lean
+++ b/NaturalNumbers/FunctionWorld/Level4.lean
@@ -11,15 +11,15 @@ Let's do the same level again a different way:
 
 ![diagram](../assets/function_diag.svg)
 
-We are given  `p  ∈ P ` and our goal is to find an element of  `U `, or
-in other words to find a path through the maze that links  `P ` to  `U `.
-In level 3 we solved this by using `have`s to move forward, from  `P `
-to  `Q ` to  `T ` to  `U `.
+We are given `p  ∈ P` and our goal is to find an element of `U`, or
+in other words to find a path through the maze that links `P` to `U`.
+In level 3 we solved this by using `have`s to move forward, from `P`
+to `Q` to `T` to `U`.
 Using the [apply tactic](../Tactics/apply.lean.md) we can instead construct
-the path backwards, moving from  `U ` to  `T ` to  `Q ` to  `P `.
+the path backwards, moving from `U` to `T` to `Q` to `P`.
 
-Our goal is to construct an element of the set  `U `. But  `l:T → U ` is
-a function, so it would suffice to construct an element of  `T `. Tell
+Our goal is to construct an element of the set `U`. But `l:T → U` is
+a function, so it would suffice to construct an element of `T`. Tell
 Lean this by starting the proof below with
 
 `apply l`
@@ -30,11 +30,11 @@ from `⊢ U` to `⊢ T`.
 Keep `apply`ing functions until your goal is `P`, and try not
 to get lost! Now solve this goal
 with `exact p`. Note: you will need to learn the difference between
-`exact p` (which works) and `exact P` (which doesn't, because  `P ` is
-not an element of  `P `).
+`exact p` (which works) and `exact P` (which doesn't, because `P` is
+not an element of  `P`).
 
 ## Definition
-Given an element of  `P ` we can define an element of  `U `.
+Given an element of `P` we can define an element of `U`.
 -/
 example (P Q R S T U: Type)
 (p : P)
@@ -51,5 +51,5 @@ example (P Q R S T U: Type)
 
 /-!
 
-Next up [Level 5](./Level5.lean.md)
+Next up [Level 5](./Level5.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld/Level5.lean
+++ b/NaturalNumbers/FunctionWorld/Level5.lean
@@ -3,9 +3,9 @@ namespace MyNat
 open MyNat
 
 /-!
-# Function world.
+# Function World
 
-## Level 5: `P → (Q → P)`.
+## Level 5: `P → (Q → P)`
 
 In this level, our goal is to construct a function, like in level 2.
 
@@ -29,7 +29,7 @@ So let's start with
 and we then find ourselves in this state:
 
 ```
-P Q : Type,
+P Q : Type
 p : P
 ⊢ Q → P
 ```
@@ -73,8 +73,8 @@ a mathematician writes `6 - 2 - 1` they mean `(6 - 2) - 1` and not `6 - (2 - 1)`
 
 ## Pro tip
 
-`intros p q` is the same as `intro p; intro q`.
+`intro p q` is the same as `intro p; intro q`.
 
 
-Next up [Level 6](./Level6.lean.md)
+Next up [Level 6](./Level6.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld/Level6.lean
+++ b/NaturalNumbers/FunctionWorld/Level6.lean
@@ -5,7 +5,7 @@ open MyNat
 /-!
 # Function World
 
-## Level 6: `(P → (Q → R)) → ((P → Q) → (P → R))`.
+## Level 6: `(P → (Q → R)) → ((P → Q) → (P → R))`
 
 You can solve this level completely just using `intro`, `apply` and `exact`,
 but if you want to argue forwards instead of backwards then don't forget
@@ -21,17 +21,17 @@ We start with `intro f` rather than `intro p`
 because even though the goal starts `P → ...`, the brackets mean that
 the goal is not a function from `P` to anything, it's a function from
 `P → (Q → R)` to something. In fact you can save time by starting
-with `intros f h p`, which introduces three variables at once, although you'd
+with `intro f h p`, which introduces three variables at once, although you'd
 better then look at your tactic state to check that you called all those new
 terms sensible things.
 
-After all the intros, you find that the goal is `⊢ R`. If you try `have j : Q → R := f p`
+After all the `intro`s, you find that the goal is `⊢ R`. If you try `have j : Q → R := f p`
 now then you can `apply j`. Alternatively you can `apply (f p)` directly.
 What happens if you just try `apply f`? Can you figure out what just happened? This is a little
 `apply` easter egg. Why is it mathematically valid?
 
 ## Definition
-Whatever the sets  `P ` and  `Q ` and  `R ` are, we
+Whatever the sets `P` and `Q` and `R` are, we
 make an element of \\(\operatorname{Hom}(\operatorname{Hom}(P,\operatorname{Hom}(Q,R)),
 \operatorname{Hom}(\operatorname{Hom}(P,Q),\operatorname{Hom}(P,R)))\\).
 -/
@@ -46,5 +46,5 @@ example (P Q R : Type) : (P → (Q → R)) → ((P → Q) → (P → R)) := by
 
 /-!
 
-Next up [Level 7](./Level7.lean.md)
+Next up [Level 7](./Level7.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld/Level6.lean
+++ b/NaturalNumbers/FunctionWorld/Level6.lean
@@ -31,7 +31,7 @@ What happens if you just try `apply f`? Can you figure out what just happened? T
 `apply` easter egg. Why is it mathematically valid?
 
 ## Definition
-Whatever the sets `P` and `Q` and `R` are, we
+Whatever the sets `P`, `Q` and `R` are, we
 make an element of \\(\operatorname{Hom}(\operatorname{Hom}(P,\operatorname{Hom}(Q,R)),
 \operatorname{Hom}(\operatorname{Hom}(P,Q),\operatorname{Hom}(P,R)))\\).
 -/

--- a/NaturalNumbers/FunctionWorld/Level7.lean
+++ b/NaturalNumbers/FunctionWorld/Level7.lean
@@ -18,7 +18,7 @@ functor.
 
 ## Definition
 
-Whatever the sets `P` and `Q` and `F` are, we
+Whatever the sets `P`, `Q` and `F` are, we
 make an element of \\(\operatorname{Hom}(\operatorname{Hom}(P,Q),
 \operatorname{Hom}(\operatorname{Hom}(Q,F),\operatorname{Hom}(P,F)))\\).
 -/

--- a/NaturalNumbers/FunctionWorld/Level7.lean
+++ b/NaturalNumbers/FunctionWorld/Level7.lean
@@ -18,17 +18,17 @@ functor.
 
 ## Definition
 
-Whatever the sets  `P ` and  `Q ` and  `F ` are, we
+Whatever the sets `P` and `Q` and `F` are, we
 make an element of \\(\operatorname{Hom}(\operatorname{Hom}(P,Q),
 \operatorname{Hom}(\operatorname{Hom}(Q,F),\operatorname{Hom}(P,F)))\\).
 -/
 example (P Q F : Type) : (P → Q) → ((Q → F) → (P → F)) := by
-  intros f h p
+  intro f h p
   apply h
   apply f
   exact p
 
 /-!
 
-Next up [Level 8](./Level8.lean.md)
+Next up [Level 8](./Level8.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld/Level8.lean
+++ b/NaturalNumbers/FunctionWorld/Level8.lean
@@ -3,7 +3,7 @@ namespace MyNat
 open MyNat
 
 /-!
-# Function world.
+# Function World
 
 ## Level 8: `(P → Q) → ((Q → empty) → (P → empty))`
 
@@ -11,26 +11,26 @@ Level 8 is the same as level 7, except we have replaced the
 set  `F` with the empty set `∅`. The same proof will work (after all, our
 previous proof worked for all sets, and the empty set is a set).
 But note that if you start with `intro f; intro h; intro p,`
-(which can incidentally be shortened to `intros f h p`,
+(which can incidentally be shortened to `intro f h p`,
 see [intros tactic](../Tactics/intros.lean.md)),
 then the local context looks like this:
 
 ```
-P Q : Type,
-f : P → Q,
-h : Q → empty,
+P Q : Type
+f : P → Q
+h : Q → empty
 p : P
 ⊢ empty
 ```
 
 and your job is to construct an element of the empty set!
 This on the face of it seems hard, but what is going on is that
-our hypotheses (we have an element of  `P `, and functions  `P → Q`
-and  `Q → ∅`) are themselves contradictory, so
+our hypotheses (we have an element of `P`, and functions `P → Q`
+and `Q → ∅`) are themselves contradictory, so
 I guess we are doing some kind of proof by contradiction at this point? However,
 if your next line is `apply h` then all of a sudden the goal
 seems like it might be possible again. If this is confusing, note
-that the proof of the previous world worked for all sets  `F `, so in particular
+that the proof of the previous world worked for all sets `F`, so in particular
 it worked for the empty set, you just probably weren't really thinking about
 this case explicitly beforehand. [Technical note to constructivists: I know
 that we are not doing a proof by contradiction. But how else do you explain
@@ -39,7 +39,7 @@ and this is OK because their hypotheses don't add up?]
 
 ## Definition
 
-Whatever the sets  `P ` and  `Q ` are, we
+Whatever the sets `P` and `Q` are, we
 make an element of \\(\operatorname{Hom}(\operatorname{Hom}(P,Q),
 \operatorname{Hom}(\operatorname{Hom}(Q,\emptyset),\operatorname{Hom}(P,\emptyset)))\\).
 -/
@@ -51,5 +51,5 @@ example (P Q : Type) : (P → Q) → ((Q → empty) → (P → empty)) := by
 
 /-!
 
-Next up [Level 9](./Level9.lean.md)
+Next up [Level 9](./Level9.lean.md).
 -/

--- a/NaturalNumbers/FunctionWorld/Level8.lean
+++ b/NaturalNumbers/FunctionWorld/Level8.lean
@@ -5,12 +5,12 @@ open MyNat
 /-!
 # Function World
 
-## Level 8: `(P → Q) → ((Q → empty) → (P → empty))`
+## Level 8: `(P → Q) → ((Q → Empty) → (P → Empty))`
 
 Level 8 is the same as level 7, except we have replaced the
-set  `F` with the empty set `∅`. The same proof will work (after all, our
+set  `F` with the empty set `∅` (`Empty`). The same proof will work (after all, our
 previous proof worked for all sets, and the empty set is a set).
-But note that if you start with `intro f; intro h; intro p,`
+But note that if you start with `intro f; intro h; intro p`
 (which can incidentally be shortened to `intro f h p`,
 see [intros tactic](../Tactics/intros.lean.md)),
 then the local context looks like this:
@@ -18,15 +18,15 @@ then the local context looks like this:
 ```
 P Q : Type
 f : P → Q
-h : Q → empty
+h : Q → Empty
 p : P
-⊢ empty
+⊢ Empty
 ```
 
 and your job is to construct an element of the empty set!
 This on the face of it seems hard, but what is going on is that
 our hypotheses (we have an element of `P`, and functions `P → Q`
-and `Q → ∅`) are themselves contradictory, so
+and `Q → Empty`) are themselves contradictory, so
 I guess we are doing some kind of proof by contradiction at this point? However,
 if your next line is `apply h` then all of a sudden the goal
 seems like it might be possible again. If this is confusing, note
@@ -43,7 +43,7 @@ Whatever the sets `P` and `Q` are, we
 make an element of \\(\operatorname{Hom}(\operatorname{Hom}(P,Q),
 \operatorname{Hom}(\operatorname{Hom}(Q,\emptyset),\operatorname{Hom}(P,\emptyset)))\\).
 -/
-example (P Q : Type) : (P → Q) → ((Q → empty) → (P → empty)) := by
+example (P Q : Type) : (P → Q) → ((Q → Empty) → (P → Empty)) := by
   intros f h p
   apply h
   apply f

--- a/NaturalNumbers/FunctionWorld/Level9.lean
+++ b/NaturalNumbers/FunctionWorld/Level9.lean
@@ -3,7 +3,7 @@ namespace MyNat
 open MyNat
 
 /-!
-# Function world.
+# Function World
 
 ## Level 9: a big maze.
 

--- a/NaturalNumbers/FunctionWorld/Level9.lean
+++ b/NaturalNumbers/FunctionWorld/Level9.lean
@@ -5,7 +5,7 @@ open MyNat
 /-!
 # Function World
 
-## Level 9: a big maze.
+## Level 9: a big maze
 
 In [Proposition World](../PropositionWorld.lean.md) you will see a variant of this example
 which can be solved by a tactic. It would be an interesting project to make a tactic

--- a/NaturalNumbers/InequalityWorld.lean
+++ b/NaturalNumbers/InequalityWorld.lean
@@ -18,7 +18,7 @@ import InequalityWorld.Level17
 -- import InequalityWorld.Level18 -- BUGBUG
 
 /-!
-# Inequality world.
+# Inequality World
 
 A new `import MyNat.Inequality` gives us a new definition. If `a` and `b` are naturals,
 `a ≤ b` is *defined* to mean
@@ -26,7 +26,7 @@ A new `import MyNat.Inequality` gives us a new definition. If `a` and `b` are na
 `∃ (c : MyNat), b = a + c`
 
 The backwards E means "there exists". So in words, `a ≤ b`
-if and only if there exists a natural `c` such that `b=a+c`.
+if and only if there exists a natural number `c` such that `b=a+c`.
 
 If you really want to change an `a ≤ b` to `∃ c, b = a + c` then
 you can do so with `rw [le_iff_exists_add]`:
@@ -46,6 +46,6 @@ There are two situations. Firstly we need to know how to solve a goal
 of the form `⊢ ∃ c, ...`, and secondly we need to know how to use a hypothesis
 of the form `∃ c, ...`.
 
-Let's dive in [Level 1](./InequalityWorld/Level1.lean.md)
+Let's dive in [Level 1](./InequalityWorld/Level1.lean.md).
 
 -/

--- a/NaturalNumbers/InequalityWorld/Level1.lean
+++ b/NaturalNumbers/InequalityWorld/Level1.lean
@@ -7,7 +7,7 @@ open MyNat
 
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 1: the [`use` tactic](../Tactics/use.lean.md)
 
@@ -54,6 +54,6 @@ lemma one_add_le_self (x : MyNat) : x ≤ 1 + x := by
 /-!
 
 
-Next up [Level 2](./Level2.lean.md)
+Next up [Level 2](./Level2.lean.md).
 
 -/

--- a/NaturalNumbers/InequalityWorld/Level1.lean
+++ b/NaturalNumbers/InequalityWorld/Level1.lean
@@ -29,7 +29,7 @@ So try
 
 and now the goal becomes `⊢ 1 + x = x + 1`. You can solve this by
 `exact add_comm 1 x`, or if you are lazy you can just use the `ring` tactic,
-which is a powerful AI which will solve any equality in algebra which can
+a powerful AI which will solve any equality in algebra that can
 be proved using the standard rules of addition and multiplication. Now
 look at your proof. We're going to remove a line.
 
@@ -43,7 +43,7 @@ this does not formally make sense, but you can do the calculation in your head).
 If you have written `rw [le_iff_exists_add]` below, then just put two minus signs `--`
 before it and comment it out. See that the proof still compiles.
 
-## Lemma : one_add_le_self
+## Lemma: `one_add_le_self`
 If `x` is a natural number, then `x ≤ 1+x`.
 -/
 lemma one_add_le_self (x : MyNat) : x ≤ 1 + x := by

--- a/NaturalNumbers/InequalityWorld/Level10.lean
+++ b/NaturalNumbers/InequalityWorld/Level10.lean
@@ -5,18 +5,18 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 10: `le_succ_self`
 
 Another simple one.
 
-## Lemma : le_succ_self
+## Lemma : `le_succ_self`
 For all naturals `a`, `a ≤ succ a.`
 -/
 lemma le_succ_self (a : MyNat) : a ≤ succ a := by
   use 1
 
 /-!
-Next up [Level 11](./Level11.lean.md)
+Next up [Level 11](./Level11.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level10.lean
+++ b/NaturalNumbers/InequalityWorld/Level10.lean
@@ -11,7 +11,7 @@ open MyNat
 
 Another simple one.
 
-## Lemma : `le_succ_self`
+## Lemma: `le_succ_self`
 For all naturals `a`, `a ≤ succ a.`
 -/
 lemma le_succ_self (a : MyNat) : a ≤ succ a := by

--- a/NaturalNumbers/InequalityWorld/Level11.lean
+++ b/NaturalNumbers/InequalityWorld/Level11.lean
@@ -6,14 +6,14 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 11: `add_le_add_right`
 
 If you're faced with a goal of the form `forall t, ...`, then the next
 line is "so let `t` be arbitrary". The way to do this in Lean is `intro t`.
 
-## Lemma : add_le_add_right
+## Lemma : `add_le_add_right`
 For all naturals `a` and `b`, `a ≤ b` implies that for all naturals `t`,
 `a+t ≤ b+t`.
 -/
@@ -27,5 +27,5 @@ theorem add_le_add_right {a b : MyNat} : a ≤ b → ∀ t, (a + t) ≤ (b + t) 
     rw [add_right_comm]
 
 /-!
-Next up [Level 12](./Level12.lean.md)
+Next up [Level 12](./Level12.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level11.lean
+++ b/NaturalNumbers/InequalityWorld/Level11.lean
@@ -13,7 +13,7 @@ open MyNat
 If you're faced with a goal of the form `forall t, ...`, then the next
 line is "so let `t` be arbitrary". The way to do this in Lean is `intro t`.
 
-## Lemma : `add_le_add_right`
+## Lemma: `add_le_add_right`
 For all naturals `a` and `b`, `a ≤ b` implies that for all naturals `t`,
 `a+t ≤ b+t`.
 -/

--- a/NaturalNumbers/InequalityWorld/Level12.lean
+++ b/NaturalNumbers/InequalityWorld/Level12.lean
@@ -11,7 +11,7 @@ open MyNat
 
 ## Level 12: `le_of_succ_le_succ`
 
-## Lemma : `le_of_succ_le_succ`
+## Lemma: `le_of_succ_le_succ`
 For all naturals `a` and `b`, `succ a ≤ succ b ⟹ a ≤ b`.
 -/
 theorem le_of_succ_le_succ (a b : MyNat) : succ a ≤ succ b → a ≤ b := by

--- a/NaturalNumbers/InequalityWorld/Level12.lean
+++ b/NaturalNumbers/InequalityWorld/Level12.lean
@@ -7,12 +7,12 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 12: `le_of_succ_le_succ`
 
-## Lemma : le_of_succ_le_succ
-For all naturals `a` and `b`, `succ a ≤ succ b ⟹ a ≤ b.`
+## Lemma : `le_of_succ_le_succ`
+For all naturals `a` and `b`, `succ a ≤ succ b ⟹ a ≤ b`.
 -/
 theorem le_of_succ_le_succ (a b : MyNat) : succ a ≤ succ b → a ≤ b := by
   intro h
@@ -24,5 +24,5 @@ theorem le_of_succ_le_succ (a b : MyNat) : succ a ≤ succ b → a ≤ b := by
     exact succ_add a c
 
 /-!
-Next up [Level 13](./Level13.lean.md)
+Next up [Level 13](./Level13.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level13.lean
+++ b/NaturalNumbers/InequalityWorld/Level13.lean
@@ -7,14 +7,14 @@ open MyNat
 
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 13: `not_succ_le_self`
 
-Turns out that `¬ P` is *by definition* `P → false`, so you can just
+Turns out that `¬ P` is *by definition* `P → False`, so you can just
 start this one with `intro h` if you like.
 
-##  Lemma : not_succ_le_self
+##  Lemma : `not_succ_le_self`
 For all naturals `a`, `succ a` is not at most `a`.
 -/
 theorem not_succ_le_self (a : MyNat) : ¬ (succ a ≤ a) := by
@@ -48,8 +48,8 @@ This is an incantation which rewrites `hc` only on the left hand side of the goa
 You didn't need to use `conv` in the above proof
 but it's a helpful trick when `rw` is rewriting too much.
 
-For a deeper discussion on `conv` see [Conversion Tactic Mode](https://leanprover.github.io/theorem_proving_in_lean4/conv.html)
+For a deeper discussion on `conv` see [Conversion Tactic Mode](https://leanprover.github.io/theorem_proving_in_lean4/conv.html).
 
 
-Next up [Level 14](./Level14.lean.md)
+Next up [Level 14](./Level14.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level13.lean
+++ b/NaturalNumbers/InequalityWorld/Level13.lean
@@ -14,7 +14,7 @@ open MyNat
 Turns out that `¬ P` is *by definition* `P → False`, so you can just
 start this one with `intro h` if you like.
 
-##  Lemma : `not_succ_le_self`
+##  Lemma: `not_succ_le_self`
 For all naturals `a`, `succ a` is not at most `a`.
 -/
 theorem not_succ_le_self (a : MyNat) : ¬ (succ a ≤ a) := by

--- a/NaturalNumbers/InequalityWorld/Level14.lean
+++ b/NaturalNumbers/InequalityWorld/Level14.lean
@@ -6,18 +6,18 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 14: `add_le_add_left`
 
 I know these are easy and we've done several already, but this is one
 of the axioms for an ordered commutative monoid! The nature of formalizing
 is that we should formalize all "obvious" lemmas, and then when we're
-actually using ` ≤` in real life, everything will be there. Note also,
+actually using `≤` in real life, everything will be there. Note also,
 of course, that all of these lemmas are already formalized in Lean's
-maths library already, for Lean's inbuilt natural numbers.
+maths library, for Lean's inbuilt natural numbers.
 
-## Lemma : add_le_add_left
+## Lemma : `add_le_add_left`
 If `a ≤ b` then for all `t`, `t+a ≤ t+b`.
 -/
 theorem add_le_add_left {a b : MyNat} (h : a ≤ b) (t : MyNat) :
@@ -29,5 +29,5 @@ theorem add_le_add_left {a b : MyNat} (h : a ≤ b) (t : MyNat) :
     rw [add_assoc]
 
 /-!
-Next up [Level 15](./Level15.lean.md)
+Next up [Level 15](./Level15.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level14.lean
+++ b/NaturalNumbers/InequalityWorld/Level14.lean
@@ -17,7 +17,7 @@ actually using `≤` in real life, everything will be there. Note also,
 of course, that all of these lemmas are already formalized in Lean's
 maths library, for Lean's inbuilt natural numbers.
 
-## Lemma : `add_le_add_left`
+## Lemma: `add_le_add_left`
 If `a ≤ b` then for all `t`, `t+a ≤ t+b`.
 -/
 theorem add_le_add_left {a b : MyNat} (h : a ≤ b) (t : MyNat) :

--- a/NaturalNumbers/InequalityWorld/Level15.lean
+++ b/NaturalNumbers/InequalityWorld/Level15.lean
@@ -9,7 +9,7 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 15: introducing `<`
 
@@ -23,10 +23,10 @@ But a much more usable definition would be this:
 
 `a < b := succ a ≤ b`
 
-Let's prove that these two definitions are the same
+Let's prove that these two definitions are the same.
 
-## Lemma : lt_aux₁
-For all naturals `a` and `b`, `a ≤ b ∧ ¬(b ≤ a) ⟹ succ a ≤ b.`
+## Lemma : `lt_aux₁`
+For all naturals `a` and `b`, `a ≤ b ∧ ¬(b ≤ a) ⟹ succ a ≤ b`.
 -/
 lemma lt_aux₁ (a b : MyNat) : a ≤ b ∧ ¬ (b ≤ a) → succ a ≤ b := by
   intro h
@@ -47,5 +47,5 @@ lemma lt_aux₁ (a b : MyNat) : a ≤ b ∧ ¬ (b ≤ a) → succ a ≤ b := by
         rw [succ_add]
 
 /-!
-Next up [Level 16](./Level16.lean.md)
+Next up [Level 16](./Level16.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level15.lean
+++ b/NaturalNumbers/InequalityWorld/Level15.lean
@@ -25,7 +25,7 @@ But a much more usable definition would be this:
 
 Let's prove that these two definitions are the same.
 
-## Lemma : `lt_aux₁`
+## Lemma: `lt_aux₁`
 For all naturals `a` and `b`, `a ≤ b ∧ ¬(b ≤ a) ⟹ succ a ≤ b`.
 -/
 lemma lt_aux₁ (a b : MyNat) : a ≤ b ∧ ¬ (b ≤ a) → succ a ≤ b := by

--- a/NaturalNumbers/InequalityWorld/Level16.lean
+++ b/NaturalNumbers/InequalityWorld/Level16.lean
@@ -18,7 +18,7 @@ open MyNat
 
 Now let's go the other way.
 
-## Lemma : `lt_aux₂`
+## Lemma: `lt_aux₂`
 For all naturals `a` and `b`, `succ a ≤ b  ⟹ a ≤ b ∧ ¬ (b ≤ a)`.
 -/
 lemma lt_aux₂ (a b : MyNat) : succ a ≤ b → a ≤ b ∧ ¬ (b ≤ a) := by

--- a/NaturalNumbers/InequalityWorld/Level16.lean
+++ b/NaturalNumbers/InequalityWorld/Level16.lean
@@ -12,13 +12,13 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 16: equivalence of two definitions of `<`
 
 Now let's go the other way.
 
-## Lemma : lt_aux₂
+## Lemma : `lt_aux₂`
 For all naturals `a` and `b`, `succ a ≤ b  ⟹ a ≤ b ∧ ¬ (b ≤ a)`.
 -/
 lemma lt_aux₂ (a b : MyNat) : succ a ≤ b → a ≤ b ∧ ¬ (b ≤ a) := by
@@ -40,5 +40,5 @@ lemma lt_aux₂ (a b : MyNat) : succ a ≤ b → a ≤ b ∧ ¬ (b ≤ a) := by
 /-!
 Now for the payoff.
 
-Next up [Level 17](./Level17.lean.md)
+Next up [Level 17](./Level17.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level17.lean
+++ b/NaturalNumbers/InequalityWorld/Level17.lean
@@ -9,7 +9,7 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 17: definition of `<`
 
@@ -17,8 +17,8 @@ OK so we are going to *define* `a < b` by `a ≤ b ∧ ¬ (b ≤ a)`,
 and given `lt_aux_one a b` and `lt_aux_two a b` it should now just
 be a few lines to prove `a < b ↔ succ a ≤ b`.
 
-## Lemma : lt_iff_succ_le
-For all naturals `a` and `b`, `a<b ↔ succ a ≤ b.`
+## Lemma : `lt_iff_succ_le`
+For all naturals `a` and `b`, `a<b ↔ succ a ≤ b`.
 -/
 lemma lt_iff_succ_le (a b : MyNat) : a < b ↔ succ a ≤ b := by
   constructor
@@ -38,5 +38,5 @@ and ask questions in the `#new members` stream. Real names preferred. Be nice.
 -/
 
 /-!
-If you want to see a whole bunch of great examples see [Level 18](./Level18.lean.md)
+If you want to see a whole bunch of great examples see [Level 18](./Level18.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level17.lean
+++ b/NaturalNumbers/InequalityWorld/Level17.lean
@@ -17,7 +17,7 @@ OK so we are going to *define* `a < b` by `a ≤ b ∧ ¬ (b ≤ a)`,
 and given `lt_aux_one a b` and `lt_aux_two a b` it should now just
 be a few lines to prove `a < b ↔ succ a ≤ b`.
 
-## Lemma : `lt_iff_succ_le`
+## Lemma: `lt_iff_succ_le`
 For all naturals `a` and `b`, `a<b ↔ succ a ≤ b`.
 -/
 lemma lt_iff_succ_le (a b : MyNat) : a < b ↔ succ a ≤ b := by

--- a/NaturalNumbers/InequalityWorld/Level2.lean
+++ b/NaturalNumbers/InequalityWorld/Level2.lean
@@ -8,7 +8,7 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 Here's a nice easy one.
 
@@ -70,5 +70,5 @@ different places. `rfl` closes a goal of the form `X = Y` if `X` and `Y` are
 definitionally equal.
 
 
-Next up [Level 3](./Level3.lean.md)
+Next up [Level 3](./Level3.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level2.lean
+++ b/NaturalNumbers/InequalityWorld/Level2.lean
@@ -12,9 +12,9 @@ open MyNat
 
 Here's a nice easy one.
 
-## Level 2: le_refl
+## Level 2: `le_refl`
 
-## Lemma :
+## Lemma
 The `≤` relation is reflexive. In other words, if `x` is a natural number,
 then `x ≤ x`.
 -/

--- a/NaturalNumbers/InequalityWorld/Level3.lean
+++ b/NaturalNumbers/InequalityWorld/Level3.lean
@@ -6,7 +6,7 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 3: `le_succ_of_le`
 
@@ -57,5 +57,5 @@ Now what about if you do `use 1 + c`? Can you work out
 what is going on? Does it help if I tell you that the *definition*
 of `1` is `succ 0`?
 
-Next up [Level 4](./Level4.lean.md)
+Next up [Level 4](./Level4.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level3.lean
+++ b/NaturalNumbers/InequalityWorld/Level3.lean
@@ -38,8 +38,8 @@ elected not to do the definitional rewriting) so
 gives you the natural number `c` and the hypothesis `hc : b = a + c`.
 Now use `use` wisely and you're home.
 
-## Lemma : le_succ
-For all naturals `a`, `b`, if `a ≤ b` then `a ≤ succ b`.
+## Lemma: `le_succ`
+For all naturals `a` and `b`, if `a ≤ b` then `a ≤ succ b`.
 -/
 theorem le_succ (a b : MyNat) : a ≤ b → a ≤ (succ b) := by
   intro h

--- a/NaturalNumbers/InequalityWorld/Level4.lean
+++ b/NaturalNumbers/InequalityWorld/Level4.lean
@@ -6,7 +6,7 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 4: `zero_le`
 
@@ -20,5 +20,5 @@ lemma zero_le (a : MyNat) : 0 ≤ a := by
   rw [zero_add]
 
 /-!
-Next up [Level 5](./Level5.lean.md)
+Next up [Level 5](./Level5.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level4.lean
+++ b/NaturalNumbers/InequalityWorld/Level4.lean
@@ -12,7 +12,7 @@ open MyNat
 
 Another easy one.
 
-## Lemma : zero_le
+## Lemma: `zero_le`
 For all naturals `a`, `0 ≤ a`.
 -/
 lemma zero_le (a : MyNat) : 0 ≤ a := by

--- a/NaturalNumbers/InequalityWorld/Level5.lean
+++ b/NaturalNumbers/InequalityWorld/Level5.lean
@@ -8,14 +8,14 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 5: `le_trans`
 
 Another straightforward one.
 
 ## Lemma : le_trans
-≤ is transitive. In other words, if `a ≤ b` and `b ≤ c` then `a ≤ c`.
+`≤` is transitive. In other words, if `a ≤ b` and `b ≤ c` then `a ≤ c`.
 -/
 theorem le_trans (a b c : MyNat) (hab : a ≤ b) (hbc : b ≤ c) : a ≤ c := by
   cases hab with
@@ -35,5 +35,5 @@ instance : Preorder MyNat :=
   ⟨le_refl_mynat, le_trans, lt⟩
 
 /-!
-Next up [Level 6](./Level6.lean.md)
+Next up [Level 6](./Level6.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level5.lean
+++ b/NaturalNumbers/InequalityWorld/Level5.lean
@@ -14,7 +14,7 @@ open MyNat
 
 Another straightforward one.
 
-## Lemma : le_trans
+## Lemma: `le_trans`
 `≤` is transitive. In other words, if `a ≤ b` and `b ≤ c` then `a ≤ c`.
 -/
 theorem le_trans (a b c : MyNat) (hab : a ≤ b) (hbc : b ≤ c) : a ≤ c := by

--- a/NaturalNumbers/InequalityWorld/Level6.lean
+++ b/NaturalNumbers/InequalityWorld/Level6.lean
@@ -24,7 +24,7 @@ a hypothesis `h : c + d = 0` then you can write
 
 `have h := eq_zero_of_add_right_eq_self hd`
 
-## Lemma : `le_antisymm`
+## Lemma: `le_antisymm`
 `≤` is antisymmetric. In other words, if `a ≤ b` and `b ≤ a` then `a = b`.
 -/
 theorem le_antisymm (a b : MyNat) (hab : a ≤ b) (hba : b ≤ a) : a = b := by

--- a/NaturalNumbers/InequalityWorld/Level6.lean
+++ b/NaturalNumbers/InequalityWorld/Level6.lean
@@ -8,7 +8,7 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 6: `le_antisymm`
 
@@ -16,7 +16,7 @@ In Advanced Addition World you proved
 
 `eq_zero_of_add_right_eq_self (a b : MyNat) : a + b = a → b = 0`.
 
-This might be useful in this level.
+That might be useful in this level.
 
 Another tip: if you want to create a new hypothesis, you can use the `have` tactic.
 For example, if you have a hypothesis `hd : a + (c + d) = a` and you want
@@ -24,7 +24,7 @@ a hypothesis `h : c + d = 0` then you can write
 
 `have h := eq_zero_of_add_right_eq_self hd`
 
-## Lemma : le_antisymm
+## Lemma : `le_antisymm`
 `≤` is antisymmetric. In other words, if `a ≤ b` and `b ≤ a` then `a = b`.
 -/
 theorem le_antisymm (a b : MyNat) (hab : a ≤ b) (hba : b ≤ a) : a = b := by
@@ -47,5 +47,5 @@ This proved that the natural numbers are a partial order!
 -- instance : partial_order MyNat := by structure_helper
 
 /-!
-Next up [Level 7](./Level7.lean.md)
+Next up [Level 7](./Level7.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level7.lean
+++ b/NaturalNumbers/InequalityWorld/Level7.lean
@@ -12,7 +12,7 @@ We proved `add_right_eq_zero` back in advanced addition world.
 Remember that you can do things like `have h2 := add_right_eq_zero h1`
 if `h1 : a + c = 0`.
 
-### Lemma : `le_zero`
+### Lemma: `le_zero`
 For all naturals `a`, if `a ≤ 0` then `a = 0`.
 -/
 lemma le_zero (a : MyNat) (h : a ≤ 0) : a = 0 := by

--- a/NaturalNumbers/InequalityWorld/Level7.lean
+++ b/NaturalNumbers/InequalityWorld/Level7.lean
@@ -4,7 +4,7 @@ import AdvancedAdditionWorld.Level11 -- add_right_eq_zero
 namespace MyNat
 open MyNat
 /-!
-# Inequality world
+# Inequality World
 
 ## Level 7: `le_zero`
 
@@ -12,7 +12,7 @@ We proved `add_right_eq_zero` back in advanced addition world.
 Remember that you can do things like `have h2 := add_right_eq_zero h1`
 if `h1 : a + c = 0`.
 
-### Lemma : le_zero
+### Lemma : `le_zero`
 For all naturals `a`, if `a ≤ 0` then `a = 0`.
 -/
 lemma le_zero (a : MyNat) (h : a ≤ 0) : a = 0 := by
@@ -22,5 +22,5 @@ lemma le_zero (a : MyNat) (h : a ≤ 0) : a = 0 := by
     exact add_right_eq_zero hc
 
 /-!
-Next up [Level 8](./Level8.lean.md)
+Next up [Level 8](./Level8.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level8.lean
+++ b/NaturalNumbers/InequalityWorld/Level8.lean
@@ -6,7 +6,7 @@ namespace MyNat
 open MyNat
 /-!
 
-# Inequality world.
+# Inequality World
 
 ## Level 8: `succ_le_succ`
 
@@ -24,5 +24,5 @@ lemma succ_le_succ (a b : MyNat) (h : a ≤ b) : succ a ≤ succ b := by
 
 
 /-!
-Next up [Level 9](./Level9.lean.md)
+Next up [Level 9](./Level9.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level8.lean
+++ b/NaturalNumbers/InequalityWorld/Level8.lean
@@ -12,7 +12,7 @@ open MyNat
 
 Another straightforward one.
 
-## Lemma : succ_le_succ
+## Lemma: `succ_le_succ`
 For all naturals `a` and `b`, if `a ≤ b`, then `succ a ≤ succ b`.
 -/
 lemma succ_le_succ (a b : MyNat) (h : a ≤ b) : succ a ≤ succ b := by

--- a/NaturalNumbers/InequalityWorld/Level9.lean
+++ b/NaturalNumbers/InequalityWorld/Level9.lean
@@ -7,11 +7,11 @@ import InequalityWorld.Level8 -- succ_le_succ
 namespace MyNat
 open MyNat
 /-!
-# Inequality world.
+# Inequality World
 
 ## Level 9: `le_total`
 
-## Lemma : le_total
+## Lemma : `le_total`
 For all naturals `a` and `b`, either `a ≤ b` or `b ≤ a`.
 -/
 theorem le_total (a b : MyNat) : a ≤ b ∨ b ≤ a := by
@@ -52,5 +52,5 @@ Another collectible: the naturals are a linear order.
 -- BUGBUG: collectibles
 -- instance : linear_order MyNat := by structure_helper
 
-Next up [Level 10](./Level10.lean.md)
+Next up [Level 10](./Level10.lean.md).
 -/

--- a/NaturalNumbers/InequalityWorld/Level9.lean
+++ b/NaturalNumbers/InequalityWorld/Level9.lean
@@ -11,7 +11,7 @@ open MyNat
 
 ## Level 9: `le_total`
 
-## Lemma : `le_total`
+## Lemma: `le_total`
 For all naturals `a` and `b`, either `a ≤ b` or `b ≤ a`.
 -/
 theorem le_total (a b : MyNat) : a ≤ b ∨ b ≤ a := by

--- a/NaturalNumbers/MultiplicationWorld/Level1.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level1.lean
@@ -9,7 +9,7 @@ open MyNat
 
 ## Lemma
 
-For all natural numbers `m`, we have ` 0 * m = 0. `
+For all natural numbers `m`, we have ` 0 * m = 0`.
 -/
 lemma zero_mul (m : MyNat) : 0 * m = 0 := by
   induction m with

--- a/NaturalNumbers/MultiplicationWorld/Level2.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level2.lean
@@ -20,7 +20,7 @@ behaves with respect to multiplication.
 
 ## Lemma
 
-For any natural number `m`, we have `m * 1 = m.`
+For any natural number `m`, we have `m * 1 = m`.
 -/
 lemma mul_one (m : MyNat) : m * 1 = m := by
   rw [one_eq_succ_zero]

--- a/NaturalNumbers/MultiplicationWorld/Level3.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level3.lean
@@ -21,7 +21,7 @@ identity for addition with `add_zero` and `zero_add`).
 
 ## Lemma
 
-For any natural number `m`, we have `1 * m = m.`
+For any natural number `m`, we have `1 * m = m`.
 -/
 lemma one_mul (m : MyNat) : 1 * m = m := by
   induction m with

--- a/NaturalNumbers/MultiplicationWorld/Level4.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level4.lean
@@ -29,7 +29,7 @@ an alternative name for the proof of this lemma.
 
 Multiplication is distributive over addition.
 In other words, for all natural numbers `a`, `b` and `t`, we have
-` t(a + b) = ta + tb`.
+`t(a + b) = ta + tb`.
 -/
 
 lemma mul_add (t a b : MyNat) : t * (a + b) = t * a + t * b := by

--- a/NaturalNumbers/MultiplicationWorld/Level4.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level4.lean
@@ -29,7 +29,7 @@ an alternative name for the proof of this lemma.
 
 Multiplication is distributive over addition.
 In other words, for all natural numbers `a`, `b` and `t`, we have
-` t(a + b) = ta + tb. `
+` t(a + b) = ta + tb`.
 -/
 
 lemma mul_add (t a b : MyNat) : t * (a + b) = t * a + t * b := by

--- a/NaturalNumbers/MultiplicationWorld/Level5.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level5.lean
@@ -21,7 +21,7 @@ to complete the goal?
 
 Multiplication is associative.
 In other words, for all natural numbers `a`, `b` and `c`, we have
-` (ab)c = a(bc). `
+`(ab)c = a(bc)`.
 -/
 lemma mul_assoc (a b c : MyNat) : (a * b) * c = a * (b * c) := by
   induction c with

--- a/NaturalNumbers/MultiplicationWorld/Level6.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level6.lean
@@ -27,7 +27,7 @@ of rewrites of `add_assoc` and `add_comm`. Use if
 you're getting lazy!
 
 ## Lemma
-For all natural numbers `a` and `b`, we have `succ a * b = ab + b.`
+For all natural numbers `a` and `b`, we have `succ a * b = ab + b`.
 -/
 lemma succ_mul (a b : MyNat) : succ a * b = a * b + b := by
   induction b with

--- a/NaturalNumbers/MultiplicationWorld/Level7.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level7.lean
@@ -25,7 +25,7 @@ just try `simp`.
 
 Addition is distributive over multiplication.
 In other words, for all natural numbers `a`, `b` and `t`, we have
-`(a + b) * t = at + bt.`
+`(a + b) * t = at + bt`.
 -/
 lemma add_mul (a b t : MyNat) : (a + b) * t = a * t + b * t := by
   induction b with
@@ -52,7 +52,7 @@ def right_distrib := add_mul -- alternative name
 -- BUGBUG
 
 /-!
-Lean would add that you have also proved that they are a `distrib`.
+Lean would add that you have also proved they are a `distrib`.
 However this concept has no mathematical name at all -- this says something
 about the regard with which mathematicians hold this collectible.
 This is an artifact of the set-up of collectibles in Lean. You consider politely

--- a/NaturalNumbers/MultiplicationWorld/Level9.lean
+++ b/NaturalNumbers/MultiplicationWorld/Level9.lean
@@ -19,7 +19,7 @@ Re-read the docs for `rw` so you know all the tricks.
 You can see them in the [Tactics section](../Tactics.lean.md) on the left.
 
 ## Lemma
-For all natural numbers `a` `b` and `c`, we have `a(bc) = b(ac)`
+For all natural numbers `a` `b` and `c`, we have `a(bc) = b(ac)`.
 -/
 lemma mul_left_comm (a b c : MyNat) : a * (b * c) = b * (a * c) := by
   rw [←mul_assoc]

--- a/NaturalNumbers/MyNat/Addition.lean
+++ b/NaturalNumbers/MyNat/Addition.lean
@@ -3,12 +3,12 @@ namespace MyNat
 open MyNat
 
 /--
-This theorem proves that if you add zero to a MyNat you get back the same number.
+This theorem proves that if you add zero to a `MyNat` you get back the same number.
 -/
 
 theorem add_zero (a : MyNat) : a + 0 = a := by rfl
 
 /--
-This theorem proves that (a + (d + 1)) = ((a + d) + 1) for a,d in MyNat.
+This theorem proves that `(a + (d + 1)) = ((a + d) + 1)` for `a` and `d` in `MyNat`.
 -/
 theorem add_succ (a d : MyNat) : a + (succ d) = succ (a + d) := by rfl

--- a/NaturalNumbers/PowerWorld/Level1.lean
+++ b/NaturalNumbers/PowerWorld/Level1.lean
@@ -15,5 +15,5 @@ lemma zero_pow_zero : (0 : MyNat) ^ (0 : MyNat) = 1 := by
   rw [pow_zero]
 
 /-!
-That was easy!  Next up [Level 2](./Level2.lean.md)
+That was easy!  Next up [Level 2](./Level2.lean.md).
 -/

--- a/NaturalNumbers/PowerWorld/Level2.lean
+++ b/NaturalNumbers/PowerWorld/Level2.lean
@@ -18,5 +18,5 @@ lemma zero_pow_succ (m : MyNat) : (0 : MyNat) ^ (succ m) = 0 := by
 
 
 /-!
-Next up [Level 3](./Level3.lean.md)
+Next up [Level 3](./Level3.lean.md).
 -/

--- a/NaturalNumbers/PowerWorld/Level3.lean
+++ b/NaturalNumbers/PowerWorld/Level3.lean
@@ -21,5 +21,5 @@ lemma pow_one (a : MyNat) : a ^ (1 : MyNat) = a := by
 
 
 /-!
-Next up [Level 4](./Level4.lean.md)
+Next up [Level 4](./Level4.lean.md).
 -/

--- a/NaturalNumbers/PowerWorld/Level4.lean
+++ b/NaturalNumbers/PowerWorld/Level4.lean
@@ -23,5 +23,5 @@ lemma one_pow (m : MyNat) : (1 : MyNat) ^ m = 1 := by
 
 
 /-!
-Next up [Level 5](./Level5.lean.md)
+Next up [Level 5](./Level5.lean.md).
 -/

--- a/NaturalNumbers/PowerWorld/Level5.lean
+++ b/NaturalNumbers/PowerWorld/Level5.lean
@@ -11,7 +11,7 @@ open MyNat
 ## Level 5: `pow_add`
 
 ## Lemma
-For all naturals `a`, `m`, `n`, we have `a^(m + n) = a ^ m  a ^ n`.
+For all naturals `a`, `m`, `n`, we have `a^(m + n) = a ^ m * a ^ n`.
 -/
 lemma pow_add (a m n : MyNat) : a ^ (m + n) = a ^ m * a ^ n := by
   induction n with
@@ -33,5 +33,5 @@ Remember you can combine all the `rw` rules into one with
 broken it out here so you can more easily see all the intermediate
 goal states.
 
-Next up [Level 6](./Level6.lean.md)
+Next up [Level 6](./Level6.lean.md).
 -/

--- a/NaturalNumbers/PowerWorld/Level5.lean
+++ b/NaturalNumbers/PowerWorld/Level5.lean
@@ -11,7 +11,7 @@ open MyNat
 ## Level 5: `pow_add`
 
 ## Lemma
-For all naturals `a`, `m`, `n`, we have `a^(m + n) = a ^ m * a ^ n`.
+For all naturals `a`, `m` and `n`, we have `a^(m + n) = a ^ m * a ^ n`.
 -/
 lemma pow_add (a m n : MyNat) : a ^ (m + n) = a ^ m * a ^ n := by
   induction n with

--- a/NaturalNumbers/PowerWorld/Level6.lean
+++ b/NaturalNumbers/PowerWorld/Level6.lean
@@ -15,7 +15,7 @@ Here we use the `attribute [simp]` additions we made in
 so that the `simp` tactic can simplify expressions involving `*`.
 
 ## Lemma
-For all naturals `a`, `b`, `n`, we have `(ab) ^ n = a ^ n * b ^ n`.
+For all naturals `a`, `b` and `n`, we have `(ab) ^ n = a ^ n * b ^ n`.
 -/
 lemma mul_pow (a b n : MyNat) : (a * b) ^ n = a ^ n * b ^ n := by
   induction n with

--- a/NaturalNumbers/PowerWorld/Level6.lean
+++ b/NaturalNumbers/PowerWorld/Level6.lean
@@ -11,11 +11,11 @@ open MyNat
 ## Level 6: `mul_pow`
 
 Here we use the `attribute [simp]` additions we made in
-[level 9 of Multiplication World](../MultiplicationWorld/Level9.lean.md)
+[Level 9 of Multiplication World](../MultiplicationWorld/Level9.lean.md)
 so that the `simp` tactic can simplify expressions involving `*`.
 
 ## Lemma
-For all naturals `a`, `b`, `n`, we have `(ab) ^ n = a ^ nb ^ n`.
+For all naturals `a`, `b`, `n`, we have `(ab) ^ n = a ^ n * b ^ n`.
 -/
 lemma mul_pow (a b n : MyNat) : (a * b) ^ n = a ^ n * b ^ n := by
   induction n with
@@ -30,5 +30,5 @@ lemma mul_pow (a b n : MyNat) : (a * b) ^ n = a ^ n * b ^ n := by
 
 
 /-!
-Next up [Level 7](./Level7.lean.md)
+Next up [Level 7](./Level7.lean.md).
 -/

--- a/NaturalNumbers/PowerWorld/Level7.lean
+++ b/NaturalNumbers/PowerWorld/Level7.lean
@@ -12,7 +12,7 @@ open MyNat
 Boss level! What will the collectible be?
 
 ## Lemma
-For all naturals `a`, `m`, `n`, we have `(a ^ m) ^ n = a ^ mn`.
+For all naturals `a`, `m` and `n`, we have `(a ^ m) ^ n = a ^ mn`.
 -/
 lemma pow_pow (a m n : MyNat) : (a ^ m) ^ n = a ^ (m * n) := by
   induction n with

--- a/NaturalNumbers/PowerWorld/Level7.lean
+++ b/NaturalNumbers/PowerWorld/Level7.lean
@@ -12,7 +12,7 @@ open MyNat
 Boss level! What will the collectible be?
 
 ## Lemma
-For all naturals `a`, `m`, `n`, we have `(a ^ m) ^ n = a ^ {mn}`.
+For all naturals `a`, `m`, `n`, we have `(a ^ m) ^ n = a ^ mn`.
 -/
 lemma pow_pow (a m n : MyNat) : (a ^ m) ^ n = a ^ (m * n) := by
   induction n with
@@ -36,5 +36,5 @@ But what is this? It's one of those twists where there's another
 boss after the boss you thought was the final boss! Go to the next
 level!
 
-Next up [Level 8](./Level8.lean.md)
+Next up [Level 8](./Level8.lean.md).
 -/

--- a/NaturalNumbers/PowerWorld/Level8.lean
+++ b/NaturalNumbers/PowerWorld/Level8.lean
@@ -21,7 +21,7 @@ have theorems about, which is `1` and `0`.
 def two : MyNat := 2
 def two_eq_succ_one : two = succ 1 := by rfl
 lemma one_plus_one : (1 : MyNat) + (1 : MyNat) = (2 : MyNat) := by rfl
--- and we already have one_eq_succ_zero.
+-- and we already have `one_eq_succ_zero`.
 
 /-!
 Now we are ready to tackle the proof:
@@ -47,7 +47,7 @@ It is also helpful to teach `simp` our new tricks:
 attribute [simp] pow_succ pow_one pow_zero
 
 /-!
-There is some fun discussion on [Lean3 Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/function.20with.20random.20definition/near/179723073)
+There is some fun discussion on [Lean Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/function.20with.20random.20definition/near/179723073)
 about different ways to solve this one in fewer steps.
 Feel free to try some of those solutions here, just note that the Lean 4 syntax is a bit different,
 no commas between tactics, and square brackets are required on the `rw` tactic.
@@ -56,14 +56,14 @@ Do you fancy doing `(a+b)^3` now? You might want to read
 [this Xena Project blog post](https://xenaproject.wordpress.com/2018/06/13/ab3/) before you start though.
 
 If you got this far -- very well done! If you only learnt the three
-tactics `rw`, `induction` and `refl` then there are now more tactics to
-learn; time to try  [Function World](../FunctionWorld.lean.md).
+tactics `rw`, `induction` and `rfl` then there are now more tactics to
+learn; time to try [Function World](../FunctionWorld.lean.md).
 
 The main thing we really want to impress upon people is that we believe
 that *all of pure mathematics* can be done in this new way.
 
 The [Liquid Tensor Experiment](https://xenaproject.wordpress.com/2022/09/12/beyond-the-liquid-tensor-experiment/)
-shows that Lean 3 could be used to prove very large math theorems.
+shows that Lean can be used to prove very large math theorems.
 
 Lean 3 also has a [definition of perfectoid spaces](https://leanprover-community.github.io/lean-perfectoid-spaces/)
 (a very complex modern mathematical structure). We believe that these systems will one day
@@ -73,7 +73,7 @@ mathematicians believe.
 
 If you want to get involved, come and join
 us at the [Zulip Lean chat](https://leanprover.zulipchat.com").
-The #new members stream is a great place to start asking questions.
+The `#new members` stream is a great place to start asking questions.
 
 Next up [Function World](../FunctionWorld.lean.md).
 -/

--- a/NaturalNumbers/PowerWorld/Level8.lean
+++ b/NaturalNumbers/PowerWorld/Level8.lean
@@ -13,7 +13,7 @@ open MyNat
 ## Level 8: `add_squared`
 
 ## Theorem
-For all naturals `a` and `b`, we have `(a + b)^2 = a^2 + b^2 + 2ab.`
+For all naturals `a` and `b`, we have `(a + b)^2 = a^2 + b^2 + 2ab`.
 
 The first step in writing this proof is to convert `2` into something we
 have theorems about, which is `1` and `0`.
@@ -50,7 +50,7 @@ attribute [simp] pow_succ pow_one pow_zero
 There is some fun discussion on [Lean3 Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/function.20with.20random.20definition/near/179723073)
 about different ways to solve this one in fewer steps.
 Feel free to try some of those solutions here, just note that the Lean 4 syntax is a bit different,
-no commands between tactics, and square brackets are required on the `rw` tactic.
+no commas between tactics, and square brackets are required on the `rw` tactic.
 
 Do you fancy doing `(a+b)^3` now? You might want to read
 [this Xena Project blog post](https://xenaproject.wordpress.com/2018/06/13/ab3/) before you start though.
@@ -63,7 +63,7 @@ The main thing we really want to impress upon people is that we believe
 that *all of pure mathematics* can be done in this new way.
 
 The [Liquid Tensor Experiment](https://xenaproject.wordpress.com/2022/09/12/beyond-the-liquid-tensor-experiment/)
-shows that Lean3 could be used to prove very large math theorems.
+shows that Lean 3 could be used to prove very large math theorems.
 
 Lean 3 also has a [definition of perfectoid spaces](https://leanprover-community.github.io/lean-perfectoid-spaces/)
 (a very complex modern mathematical structure). We believe that these systems will one day

--- a/NaturalNumbers/PropositionWorld.lean
+++ b/NaturalNumbers/PropositionWorld.lean
@@ -9,10 +9,10 @@ import PropositionWorld.Level8
 import PropositionWorld.Level9
 /-!
 
-# Proposition world.
+# Proposition world
 
 A Proposition is a true/false statement, like `2 + 2 = 4` or `2 + 2 = 5`.
-Just like we can have concrete sets in Lean like `MyNat`, and abstract
+Just as we can have concrete sets in Lean like `MyNat`, and abstract
 sets called things like `X`, we can also have concrete propositions like
 `2 + 2 = 5` and abstract propositions called things like `P`.
 
@@ -52,5 +52,5 @@ theorems, not constructing elements of sets. Or are we?
 In Lean, Propositions, like sets, are types, and proofs, like elements of sets, are terms.
 
 
-Let's get started [Level 1](./PropositionWorld/Level1.lean.md)
+Let's get started [Level 1](./PropositionWorld/Level1.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level1.lean
+++ b/NaturalNumbers/PropositionWorld/Level1.lean
@@ -3,17 +3,17 @@ namespace MyNat
 open MyNat
 /-!
 
-# Proposition world.
+# Proposition World
 
-## Level 1: the `exact` tactic.
+## Level 1: the `exact` tactic
 
 
 The local context (or tactic state) at the beginning of
 the example below looks like this:
 
 ```
-P Q : Prop,
-p : P,
+P Q : Prop
+p : P
 h : P → Q
 ⊢ Q
 ```
@@ -50,5 +50,5 @@ example (P Q : Prop) (p : P) (h : P → Q) : Q := by
 Look familiar? The reason this works so elegantly is because the Lean programming language
 has unified Propositions with the Type system of the language.
 
-Next up [Level 2](./Level2.lean.md)
+Next up [Level 2](./Level2.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level2.lean
+++ b/NaturalNumbers/PropositionWorld/Level2.lean
@@ -7,8 +7,8 @@ open MyNat
 ## Level 2: `intro`
 
 Let's prove an implication. Let `P` be a true/false statement, and let's prove that `P → P`. You
-will see that our goal in the lemma below starts out with `P → P`. Constructing a term of type `P →
-P` (which is what solving this goal *means*) in this case amounts to proving that `P → P`, and
+will see that our goal in the lemma below starts out with `P → P`. Constructing a term of type `P → P`
+(which is what solving this goal *means*) in this case amounts to proving that `P → P`, and
 computer scientists think of this as coming up with a function which sends proofs of `P` to proofs
 of `P`.
 
@@ -52,7 +52,7 @@ confuse a true/false statement (which could be false!) with a proof.
 We will stick with the convention of capital letters for propositions
 and small letters for proofs.
 
-## Lemma : imp_self
+## Lemma: `imp_self`
 If `P` is a proposition then `P → P`.
 -/
 lemma imp_self (P : Prop) : P → P := by

--- a/NaturalNumbers/PropositionWorld/Level2.lean
+++ b/NaturalNumbers/PropositionWorld/Level2.lean
@@ -2,9 +2,9 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Proposition world.
+# Proposition World
 
-## Level 2: `intro`.
+## Level 2: `intro`
 
 Let's prove an implication. Let `P` be a true/false statement, and let's prove that `P → P`. You
 will see that our goal in the lemma below starts out with `P → P`. Constructing a term of type `P →
@@ -16,7 +16,7 @@ To define an implication `P ⟹ Q` we need to choose an arbitrary proof `p : P` 
 perhaps using `p`, construct a proof of `Q`.  The Lean way to say "let's assume `P` is true" is
 `intro p`, i.e., "let's assume we have a proof of `P`".
 
-## Note for worriers.
+## Note for worriers
 
 Those of you who know something about the subtle differences between truth and provability
 discovered by Goedel -- these are not relevant here. Imagine we are working in a fixed model of
@@ -37,7 +37,7 @@ To solve the goal below, you have to come up with a function from
 local context now looks like this:
 
 ```
-P : Prop,
+P : Prop
 p : P
 ⊢ P
 ```
@@ -61,5 +61,5 @@ lemma imp_self (P : Prop) : P → P := by
 
 
 /-!
-Next up [Level 3](./Level3.lean.md)
+Next up [Level 3](./Level3.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level3.lean
+++ b/NaturalNumbers/PropositionWorld/Level3.lean
@@ -2,9 +2,9 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Proposition world.
+# Proposition World
 
-## Level 3: `have`.
+## Level 3: `have`
 
 Say you have a whole bunch of propositions and implications between them, and your goal is to build
 a certain proof of a certain proposition. If it helps, you can build intermediate proofs of other
@@ -66,15 +66,15 @@ in this proof in Visual Studio Code, and note that the tactic state at the begin
 this mess:
 
 ```
-P Q R S T U : Prop,
-p : P,
-h : P → Q,
-i : Q → R,
-j : Q → T,
-k : S → T,
-l : T → U,
-q : Q,
-t : T,
+P Q R S T U : Prop
+p : P
+h : P → Q
+i : Q → R
+j : Q → T
+k : S → T
+l : T → U
+q : Q
+t : T
 u : U
 ⊢ U
 ```
@@ -83,5 +83,5 @@ It was already bad enough to start with, and we added three more terms to it. In
 learn about the `apply` tactic which solves the level using another technique, without leaving so
 much junk behind.
 
-Next up [Level 4](./Level4.lean.md)
+Next up [Level 4](./Level4.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level3.lean
+++ b/NaturalNumbers/PropositionWorld/Level3.lean
@@ -43,7 +43,7 @@ and then finish the level with
 
 `exact u`
 
-## Lemma : maze
+## Lemma: `maze`
 
 In the maze of logical implications above, if `P` is true then so is `U`.
 -/

--- a/NaturalNumbers/PropositionWorld/Level4.lean
+++ b/NaturalNumbers/PropositionWorld/Level4.lean
@@ -3,9 +3,9 @@ namespace MyNat
 open MyNat
 /-!
 
-# Proposition world.
+# Proposition World
 
-## Level 4: `apply`.
+## Level 4: `apply`
 
 Let's do the same level again a different way:
 
@@ -21,7 +21,7 @@ Our goal is to prove `U`. But `l:T ⟹ U` is
 an implication which we are assuming, so it would suffice to prove `T`.
 Tell Lean this by starting the proof below with
 
-`apply l,`
+`apply l`
 
 and notice that our assumptions don't change but *the goal changes*
 from `⊢ U` to `⊢ T`.
@@ -49,5 +49,5 @@ lemma maze₂ (P Q R S T U: Prop)
   exact p
 
 /-!
-Next up [Level 5](./Level5.lean.md)
+Next up [Level 5](./Level5.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level4.lean
+++ b/NaturalNumbers/PropositionWorld/Level4.lean
@@ -17,7 +17,7 @@ In level 3 we solved this by using `have`s to move forward, from `P`
 to `Q` to `T` to `U`. Using the `apply` tactic we can instead construct
 the path backwards, moving from `U` to `T` to `Q` to `P`.
 
-Our goal is to prove `U`. But `l:T ⟹ U` is
+Our goal is to prove `U`. But `l : T ⟹ U` is
 an implication which we are assuming, so it would suffice to prove `T`.
 Tell Lean this by starting the proof below with
 
@@ -32,7 +32,7 @@ with `exact p`. Note: you will need to learn the difference between
 `exact p` (which works) and `exact P` (which doesn't, because `P` is
 not a proof of `P`).
 
-## Lemma : maze₂
+## Lemma: `maze₂`
 We can solve a maze.
 -/
 lemma maze₂ (P Q R S T U: Prop)

--- a/NaturalNumbers/PropositionWorld/Level5.lean
+++ b/NaturalNumbers/PropositionWorld/Level5.lean
@@ -2,7 +2,7 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Proposition ∑orld
+# Proposition World
 
 ## Level 5 : `P → (Q → P)`
 

--- a/NaturalNumbers/PropositionWorld/Level5.lean
+++ b/NaturalNumbers/PropositionWorld/Level5.lean
@@ -2,9 +2,9 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Proposition world.
+# Proposition ∑orld
 
-## Level 5 : `P → (Q → P)`.
+## Level 5 : `P → (Q → P)`
 
 In this level, our goal is to construct an implication, like in level 2.
 
@@ -27,7 +27,7 @@ goal is to construct an implication then we almost always want to use the
 and we then find ourselves in this tactic state:
 
 ```
-P Q : Prop,
+P Q : Prop
 p : P
 ⊢ Q → P
 ```
@@ -72,5 +72,5 @@ is `P → Q → R` then you need to know whether `intro h` will create `h : P` o
 Make sure you understand which one.
 -/
 /-!
-Next up [Level 6](./Level6.lean.md)
+Next up [Level 6](./Level6.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level6.lean
+++ b/NaturalNumbers/PropositionWorld/Level6.lean
@@ -2,9 +2,9 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Proposition world.
+# Proposition World
 
-## Level 6: `(P → (Q → R)) → ((P → Q) → (P → R))`.
+## Level 6: `(P → (Q → R)) → ((P → Q) → (P → R))`
 
 You can solve this level completely just using `intro`, `apply` and `exact`,
 but if you want to argue forwards instead of backwards then don't forget
@@ -13,7 +13,7 @@ and `p : P`. I recommend that you start with `intro f` rather than `intro p`
 because even though the goal starts `P → ...`, the brackets mean that
 the goal is not the statement that `P` implies anything, it's the statement that
 `P ⟹ (Q ⟹ R)` implies something. In fact I'd recommend that you started
-with `intros f h p`, which introduces three variables at once.
+with `intro f h p`, which introduces three variables at once.
 You then find that your your goal is `⊢ R`. If you try `have j : Q → R := f p`
 now then you can `apply j`. Alternatively you can `apply (f p)` directly.
 What happens if you just try `apply f`? Can you figure out what just happened? This is a little
@@ -33,5 +33,5 @@ example (P Q R : Prop) : (P → (Q → R)) → ((P → Q) → (P → R)) := by
   exact p
 
 /-!
-Next up [Level 7](./Level7.lean.md)
+Next up [Level 7](./Level7.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level7.lean
+++ b/NaturalNumbers/PropositionWorld/Level7.lean
@@ -2,15 +2,15 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Function world.
+# Function World
 
 ## Level 7: `(P → Q) → ((Q → R) → (P → R))`
 
 If you start with `intro hpq` and then `intro hqr`
 the dust will clear a bit and the level will look like this:
 ```
-P Q R : Prop,
-hpq : P → Q,
+P Q R : Prop
+hpq : P → Q
 hqr : Q → R
 ⊢ P → R
 ```
@@ -34,5 +34,5 @@ The `assumption` tactic tries to solve the goal using a
 hypothesis of compatible type.  Since we have the hypothesis named `p` it finds
 it and completes the proof.
 
-Next up [Level 8](./Level8.lean.md)
+Next up [Level 8](./Level8.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level7.lean
+++ b/NaturalNumbers/PropositionWorld/Level7.lean
@@ -17,7 +17,7 @@ hqr : Q → R
 So this level is really about showing transitivity of `⟹`,
 if you like that sort of language.
 
-## Lemma : imp_trans
+## Lemma: `imp_trans`
 
 From `P ⟹ Q` and `Q ⟹ R` we can deduce `P ⟹ R`.
 -/

--- a/NaturalNumbers/PropositionWorld/Level8.lean
+++ b/NaturalNumbers/PropositionWorld/Level8.lean
@@ -5,7 +5,7 @@ open MyNat
 /-!
 # Proposition World
 
-## Level 8 : `(P → Q) → (¬ Q → ¬ P)`
+## Level 8: `(P → Q) → (¬ Q → ¬ P)`
 
 There is a false proposition `False`, with no proof. It is easy to check that `¬ Q` is equivalent to
 `Q ⟹ False`, and in this tutorial we call this
@@ -25,7 +25,7 @@ to get rid of the two occurrences of `¬`, and I'm sure you can take it from the
 your goal might be to prove `False`. At that point I guess you must be proving something by
 contradiction. Or are you?
 
-## Lemma : contrapositive
+## Lemma: `contrapositive`
 If `P` and `Q` are propositions, and `P⟹ Q`, then
 `¬ Q⟹ ¬ P`.
 -/

--- a/NaturalNumbers/PropositionWorld/Level8.lean
+++ b/NaturalNumbers/PropositionWorld/Level8.lean
@@ -3,14 +3,14 @@ namespace MyNat
 open MyNat
 
 /-!
-# Proposition world.
+# Proposition World
 
 ## Level 8 : `(P → Q) → (¬ Q → ¬ P)`
 
-There is a false proposition `false`, with no proof. It is easy to check that `¬ Q` is equivalent to
-`Q ⟹ false`, and in this tutorial we call this
+There is a false proposition `False`, with no proof. It is easy to check that `¬ Q` is equivalent to
+`Q ⟹ False`, and in this tutorial we call this
 
-`not_iff_imp_false (P : Prop) : ¬ P ↔ (P → false)`
+`not_iff_imp_false (P : Prop) : ¬ P ↔ (P → False)`
 
 which we can prove here using the `simp` tactic:
 -/
@@ -22,7 +22,7 @@ So you can start the proof of the contrapositive below with
 `repeat rw [not_iff_imp_false]`
 
 to get rid of the two occurrences of `¬`, and I'm sure you can take it from there. At some point
-your goal might be to prove `false`. At that point I guess you must be proving something by
+your goal might be to prove `False`. At that point I guess you must be proving something by
 contradiction. Or are you?
 
 ## Lemma : contrapositive
@@ -47,5 +47,5 @@ that if `P ⟺ Q` then `P = Q`, and mathematicians use this whether or not they 
 -/
 
 /-!
-Next up [Level 9](./Level9.lean.md)
+Next up [Level 9](./Level9.lean.md).
 -/

--- a/NaturalNumbers/PropositionWorld/Level9.lean
+++ b/NaturalNumbers/PropositionWorld/Level9.lean
@@ -2,9 +2,9 @@ import MyNat.Definition
 namespace MyNat
 open MyNat
 /-!
-# Proposition world.
+# Proposition World
 
-## Level 9: a big maze.
+## Level 9: a big maze
 
 Hint: Lean's "congruence closure" tactic `cc` is good at mazes. You might want to try it now.
 Perhaps I should have mentioned it earlier.

--- a/NaturalNumbers/Tactics/apply.lean
+++ b/NaturalNumbers/Tactics/apply.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic apply
+# Tactic `apply`
 
 `apply e` tries to match the current goal against the conclusion of `e`'s type.
 If it succeeds, then the tactic returns as many subgoals as the number of premises that
@@ -12,7 +12,7 @@ and first-order unification with dependent types.
 
 For example, suppose you have the goal `⊢ Q` and you have the hypothesis
 `g : P → Q` then `apply h` will construct the path backwards,
-moving the goal from  `Q` to  `P`.
+moving the goal from `Q` to `P`.
 
 
 -/

--- a/NaturalNumbers/Tactics/assumption.lean
+++ b/NaturalNumbers/Tactics/assumption.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic assumption
+# Tactic `assumption`
 
 The `assumption` tactic tries to solve the main goal using a hypothesis of compatible type, or else fails.
 Note also the `‹t›` term notation, which is a shorthand for `show t by assumption`.

--- a/NaturalNumbers/Tactics/by_cases.lean
+++ b/NaturalNumbers/Tactics/by_cases.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-## Tactic : by_cases
+## Tactic `by_cases`
 
 ## Summary
 
@@ -9,17 +9,17 @@ import MyNat.Definition
 ## Details
 
 Some logic goals cannot be proved with `intro` and `apply` and `exact`.
-The simplest example is the law of the excluded middle `¬ ¬ P → P`.
+The simplest example is the law of double negation elimination `¬ ¬ P → P`.
 You can prove this using truth tables but not with `intro`, `apply` etc.
 To do a truth table proof, the tactic `by_cases h : P` will turn a goal of
 `⊢ ¬ ¬ P → P` into two goals
 
 ```
-P : Prop,
+P : Prop
 h : P
 ⊢ ¬¬P → P
 
-P : Prop,
+P : Prop
 h : ¬P
 ⊢ ¬¬P → P
 ```

--- a/NaturalNumbers/Tactics/cases.lean
+++ b/NaturalNumbers/Tactics/cases.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic cases
+# Tactic `cases`
 
 `cases` is similar to `induction` only it drops the inductive hypothesis.
 

--- a/NaturalNumbers/Tactics/concatenate.lean
+++ b/NaturalNumbers/Tactics/concatenate.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic <;>
+# Tactic `<;>`
 
 `tac1 <;> tac2` runs `tac1` on the main goal and `tac2` on each produced goal,
 concatenating all goals produced by `tac2`.

--- a/NaturalNumbers/Tactics/constructor.lean
+++ b/NaturalNumbers/Tactics/constructor.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic constructor
+# Tactic `constructor`
 
 If the main goal's target type is an inductive type, `constructor` solves it with
 the first matching constructor, or else fails.

--- a/NaturalNumbers/Tactics/contradiction.lean
+++ b/NaturalNumbers/Tactics/contradiction.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic contradiction
+# Tactic `contradiction`
 
 The `contradiction` tactic closes the main goal if its hypotheses
 are "trivially contradictory".

--- a/NaturalNumbers/Tactics/contradiction.lean
+++ b/NaturalNumbers/Tactics/contradiction.lean
@@ -11,7 +11,7 @@ Inductive type/family with no applicable constructors
 
 Injectivity of constructors
 
-- `example (h : none = some true) : p := by contradiction  --`
+- `example (h : none = some true) : p := by contradiction`
 
 Decidable false proposition
 

--- a/NaturalNumbers/Tactics/exact.lean
+++ b/NaturalNumbers/Tactics/exact.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic exact
+# Tactic `exact`
 
 `exact e` closes the main goal if its target type matches that of `e`.
 

--- a/NaturalNumbers/Tactics/exfalso.lean
+++ b/NaturalNumbers/Tactics/exfalso.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic exfalso
+# Tactic `exfalso`
 
 ## Summary
 
@@ -14,10 +14,10 @@ is what the `exfalso` tactic does. The theorem that `False → P` is called `Fal
 so one can achieve the same effect with `apply False.elim`.
 
 You might think this is a step backwards, but if you have a hypothesis `h : ¬ P`
-then after `rw [not_iff_imp_false] at h,` you can `apply h,` to make progress.
+then after `rw [not_iff_imp_false] at h` you can `apply h` to make progress.
 
 This tactic can also be used in a proof by contradiction, where the hypotheses are enough
 to deduce a contradiction and the goal happens to be some random statement (possibly
-a False one) which you just want to simplify to `False`.
+a false one) which you just want to simplify to `False`.
 
 -/

--- a/NaturalNumbers/Tactics/have.lean
+++ b/NaturalNumbers/Tactics/have.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic have
+# Tactic `have`
 
 `have h : t := e` adds the hypothesis `h : t` to the current goal if `e` is a term
 of type `t`.

--- a/NaturalNumbers/Tactics/induction.lean
+++ b/NaturalNumbers/Tactics/induction.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic : induction
+# Tactic `induction`
 
 Assuming `x` is a variable in the local context with an inductive type, `induction x` applies induction
 on `x` to the main goal, producing one goal for each constructor of the inductive type, in which the

--- a/NaturalNumbers/Tactics/intro.lean
+++ b/NaturalNumbers/Tactics/intro.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic intro
+# Tactic `intro`
 
 If your goal is `⊢ P → Q` then `intro p` will introduce a new
 hypothesis `p : P` and change the goal to `⊢ Q`.

--- a/NaturalNumbers/Tactics/intros.lean
+++ b/NaturalNumbers/Tactics/intros.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic intros
+# Tactic `intros`
 
 The `intros` tactic is like `intro` only it can introduce multiple hypotheses at once.
 

--- a/NaturalNumbers/Tactics/leftright.lean
+++ b/NaturalNumbers/Tactics/leftright.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic left and right
+# Tactics `left` and `right`
 
 The tactics `left` and `right` work on a goal which is a type with two constructors, the classic example
 being `P ∨ Q`. To prove `P ∨ Q` it suffices to either prove `P` or prove `Q`, and once you know which one

--- a/NaturalNumbers/Tactics/repeat.lean
+++ b/NaturalNumbers/Tactics/repeat.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic : repeat
+# Tactic `repeat`
 
 `repeat x` applies tactic `x` to main goal. If the application succeeds,
 the tactic is applied recursively to the generated subgoals until it eventually fails.

--- a/NaturalNumbers/Tactics/revert.lean
+++ b/NaturalNumbers/Tactics/revert.lean
@@ -11,7 +11,7 @@ import MyNat.Definition
 If the tactic state looks like this
 
 ```
-P Q : Prop,
+P Q : Prop
 h : P
 ⊢ Q
 ```

--- a/NaturalNumbers/Tactics/revert.lean
+++ b/NaturalNumbers/Tactics/revert.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-## Tactic : revert
+## Tactic `revert`
 
 ## Summary
 

--- a/NaturalNumbers/Tactics/rewrite.lean
+++ b/NaturalNumbers/Tactics/rewrite.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic : rewrite
+# Tactic `rewrite`
 
 The `rewrite` tactic is the way to "substitute in" the value of a variable. In general, if you have a
 hypothesis of the form `A = B`, and your goal mentions the left hand side `A` somewhere, then the
@@ -10,15 +10,15 @@ hypothesis of the form `A = B`, and your goal mentions the left hand side `A` so
 So `rewrite [e]` applies identity `e` as a rewrite rule to the target of the main goal.
 
 You can also make rewrite apply the hypothesis in reverse direction by adding
-a left arrow (← or <-) before the name of the hypothesis `rewrite [←e]`.
+a left arrow (`←` or `<-`) before the name of the hypothesis `rewrite [←e]`.
 
 If `e` is a defined constant, then the equational theorems associated with `e` are used.
 This provides a convenient way to unfold `e`.
 
 `rewrite [e₁, ..., eₙ]` applies the given rules sequentially.
 
-`rewrite [e] at l` rewrites e at location(s) l, where l is either * or a list of hypotheses in the
-local context. In the latter case, a turnstile ⊢ or |- can also be used, to signify the target of the goal:
+`rewrite [e] at l` rewrites e at location(s) l, where l is either `*` or a list of hypotheses in the
+local context. In the latter case a turnstile, `⊢` or `|-`, can also be used to signify the target of the goal:
 `rewrite [e] at l ⊢`
 
 -/

--- a/NaturalNumbers/Tactics/rfl.lean
+++ b/NaturalNumbers/Tactics/rfl.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic : rfl
+# Tactic `rfl`
 
 `rfl` stands for "reflexivity", which is a fancy way of saying that it will prove any
 goal of the form `A = A`. It doesn't matter how complicated `A` is.

--- a/NaturalNumbers/Tactics/rfl.lean
+++ b/NaturalNumbers/Tactics/rfl.lean
@@ -3,7 +3,7 @@ import MyNat.Definition
 # Tactic : rfl
 
 `rfl` stands for "reflexivity", which is a fancy way of saying that it will prove any
-goal of the form A = A. It doesn't matter how complicated A is.
+goal of the form `A = A`. It doesn't matter how complicated `A` is.
 
 This is supposed to be an extensible tactic
 and users can add their own support for new reflexive relations.

--- a/NaturalNumbers/Tactics/rw.lean
+++ b/NaturalNumbers/Tactics/rw.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic : rw
+# Tactic `rw`
 
 The `rw` tactic is simply the `rewrite` tactic followed by `rfl`.
 

--- a/NaturalNumbers/Tactics/simp.lean
+++ b/NaturalNumbers/Tactics/simp.lean
@@ -1,12 +1,12 @@
 import MyNat.Definition
 /-!
-# Tactic : simp
+# Tactic `simp`
 
 The `simp` tactic uses lemmas and hypotheses to simplify the main goal target or
 non-dependent hypotheses. It has many variants:
 - `simp` simplifies the main goal target using lemmas tagged with the attribute `[simp]`.
 - `simp [h₁, h₂, ..., hₙ]` simplifies the main goal target using the lemmas tagged
-  with the attribute `[simp]` and the given `hᵢ`'s, where the `hᵢ`'s are expressions.
+  with the attribute `[simp]` and the given `hᵢ`s, where the `hᵢ`s are expressions.
   If an `hᵢ` is a defined constant `f`, then the equational lemmas associated with
   `f` are used. This provides a convenient way to unfold `f`.
 - `simp [*]` simplifies the main goal target using the lemmas tagged with the
@@ -18,7 +18,7 @@ non-dependent hypotheses. It has many variants:
   the target or another hypothesis depends on `hᵢ`, a new simplified hypothesis
   `hᵢ` is introduced, but the old one remains in the local context.
 - `simp at *` simplifies all the hypotheses and the target.
-- `simp [*] at *` simplifies target and all (propositional) hypotheses using the
+- `simp [*] at *` simplifies the target and all (propositional) hypotheses using the
   other hypotheses.
 
 -/

--- a/NaturalNumbers/Tactics/tauto.lean
+++ b/NaturalNumbers/Tactics/tauto.lean
@@ -1,7 +1,7 @@
 import MyNat.Definition
 /-!
 
-## Tactic : tauto
+## Tactic `tauto`
 
 ## Summary
 

--- a/NaturalNumbers/Tactics/tauto.lean
+++ b/NaturalNumbers/Tactics/tauto.lean
@@ -14,8 +14,8 @@ goals.
 logical reasoning -- for example it will close the following goal:
 
 ```
-P Q : Prop,
-hP : P,
+P Q : Prop
+hP : P
 hQ : Q
 ⊢ P ∧ Q
 ```

--- a/NaturalNumbers/Tactics/use.lean
+++ b/NaturalNumbers/Tactics/use.lean
@@ -1,6 +1,6 @@
 import MyNat.Definition
 /-!
-# Tactic use
+# Tactic `use`
 
 ## Summary
 
@@ -15,7 +15,7 @@ more unwise `use 0` will turn it into the impossible-to-prove
 `P(c)` is some proposition which depends on `c`. With a goal of this
 form, `use 0` will turn the goal into `⊢ P(0)`, `use x + y` (assuming
 `x` and `y` are natural numbers in your local context) will turn
-the goal into `P(x + y)` and so on.
+the goal into `P(x + y)`, and so on.
 
 
 

--- a/NaturalNumbers/TutorialWorld.lean
+++ b/NaturalNumbers/TutorialWorld.lean
@@ -19,7 +19,7 @@ Start](https://leanprover.github.io/lean4/doc/quickstart.html) for more informat
 
 To run this tutorial in Visual Studio Code, first
 clone the [https://github.com/leanprover/lean4-samples](https://github.com/leanprover/lean4-samples)
-repo.  Then you must open the `NaturalNumbers` folder in Visual Studio Code using `File/Open folder` in order
+repo.  Then you must open the `NaturalNumbers` folder in Visual Studio Code using `File/Open Folder` in order
 for it to function correctly.
 
 ## How to use this sample

--- a/NaturalNumbers/TutorialWorld/Level1.lean
+++ b/NaturalNumbers/TutorialWorld/Level1.lean
@@ -1,9 +1,9 @@
 import MyNat.Definition
 namespace MyNat
 /-!
-# Tutorial world
+# Tutorial World
 
-## Level 1: the rfl tactic
+## Level 1: the `rfl` tactic
 
 Let's learn some tactics! Let's start with the `rfl` tactic. `rfl` stands for "reflexivity", which is
 a fancy way of saying that it will prove any goal of the form `A = A`. It doesn't matter how

--- a/NaturalNumbers/TutorialWorld/Level2.lean
+++ b/NaturalNumbers/TutorialWorld/Level2.lean
@@ -2,7 +2,7 @@ import MyNat.Definition
 namespace MyNat
 /-!
 
-# Tutorial world
+# Tutorial World
 
 ## Level 2: The `rewrite` tactic
 

--- a/NaturalNumbers/TutorialWorld/Level3.lean
+++ b/NaturalNumbers/TutorialWorld/Level3.lean
@@ -3,9 +3,9 @@ namespace MyNat
 open MyNat
 /-!
 
-# Tutorial world
+# Tutorial World
 
-## Level 3: Peano's axioms.
+## Level 3: Peano's axioms
 
 The import above gives us the type `MyNat` of natural numbers. But it also gives us some other things,
 which we'll take a look at now:

--- a/NaturalNumbers/TutorialWorld/Level3.lean
+++ b/NaturalNumbers/TutorialWorld/Level3.lean
@@ -10,12 +10,12 @@ open MyNat
 The import above gives us the type `MyNat` of natural numbers. But it also gives us some other things,
 which we'll take a look at now:
 
-- a term `(0 : MyNat)`, interpreted as the `MyNat.zero`.
+- a term `0 : MyNat`, interpreted as the `MyNat.zero`.
 - a function `succ : MyNat → MyNat`, with `succ n` interpreted as "the number after n", or the successor of `n`.
 - The principle of mathematical induction.
 
 These axioms are essentially the axioms isolated by Peano which uniquely characterize the natural
-numbers (you also need recursion, but you can ignore it for now). The first axiom says that 0 is a
+numbers (you also need recursion, but you can ignore it for now). The first axiom says that `0` is a
 natural number. The second says that there is a `succ` function which eats a number and spits out the
 number after it, so `succ 0 = 1`, `succ 1 = 2`, and so on.
 
@@ -26,7 +26,7 @@ if you have infinitely many true/false statements `P(0)`, `P(1)`, `P(2)`, and so
 It's like saying that if you have a long line of dominoes, and if you knock the first one down, and
 if you know that if a domino falls down then the one after it will fall down too, then you can
 deduce that all the dominos will fall down. You can also think of it as saying that every natural
-number can be built by starting at 0 and then applying `succ` a finite number of times.
+number can be built by starting at `0` and then applying `succ` a finite number of times.
 
 Peano's insights were firstly that these axioms completely characterise the natural numbers, and
 secondly that these axioms alone can be used to build a whole bunch of other structure on the
@@ -57,7 +57,7 @@ the right hand side. Try and figure out how the goal will change, and then try i
 The answer: Lean changed `succ a` into `b`, so the goal became `succ b = succ b`. That goal is of
 the form `X = X`, so you can complete prove the proof using `rfl` which `rw` does for you.
 
-Important note : the tactic `rewrite` expects a proof afterwards (e.g. `rewrite [h1]`).
+Important note: the tactic `rewrite` expects a proof afterwards (e.g. `rewrite [h1]`).
 But `rfl` is just `rfl`.
 
 You may be wondering whether you could have just substituted in the definition of `b` and proved the

--- a/NaturalNumbers/TutorialWorld/Level4.lean
+++ b/NaturalNumbers/TutorialWorld/Level4.lean
@@ -3,7 +3,7 @@ namespace MyNat
 open MyNat
 /-!
 
-# Tutorial world
+# Tutorial World
 
 ## Level 4: addition
 
@@ -32,9 +32,9 @@ be the number after it. Note the name of this proof too -- `add_succ` tells you 
 to something. If you ever see `... + succ ...` in your goal, you should be able to use `rewrite [add_succ]`, to
 make progress.
 
-**Lemma**`
+## Lemma
 
-For all natural numbers `a`, we have `a + (succ 0`) = succ a`.
+For all natural numbers `a`, we have `a + (succ 0) = succ a`.
 -/
 lemma add_succ_zero (a : MyNat) : a + (succ 0) = succ a := by
   rewrite [add_succ]
@@ -51,7 +51,7 @@ using `rewrite [add_succ, add_zero]`.
 
 And remember `rw` also does `rfl`, you can replace the whole proof with `rw [add_succ, add_zero]`.
 
-### Examining proofs.
+### Examining proofs
 
 You might want to review this proof now; at three lines long it is your current record.
 Don't worry there are much longer proofs, in fact, the


### PR DESCRIPTION
Numerous edits of a very pedantic nature to the NaturalNumbers example, in the interests of consistency of presentation. Highlighting a couple of points 
- changed `false` to `False`
- changed `empty` to `Empty`
- changed `intros` to `intro` (I recall a discussion on Zulip where the general opinion seemed to be that `intro` should be used in preference to `intros` and that perhaps `intros` should be dropped from Lean 4).